### PR TITLE
fix: standardize agent tool params and dependabot target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   # Python dependencies via pip
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -14,6 +15,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -2528,7 +2528,7 @@ class SessionIntelligenceEngine:
 
     async def agent_register(
         self,
-        name: str,
+        agent_name: str,
         agent_type: str,
         display_name: str | None = None,
         description: str | None = None,
@@ -2542,7 +2542,7 @@ class SessionIntelligenceEngine:
         updates the existing agent's metadata and marks it as active.
 
         Args:
-            name: Unique agent name (e.g., "focused-quality-resolver")
+            agent_name: Unique agent name (e.g., "focused-quality-resolver")
             agent_type: Agent type category (e.g., "meta", "domain",
                 "specialized")
             display_name: Human-readable display name
@@ -2558,7 +2558,7 @@ class SessionIntelligenceEngine:
             debug_logger.warning("agent_register called without database")
             return AgentRegistrationResult(
                 agent_id="",
-                name=name,
+                name=agent_name,
                 status="error",
                 message=(
                     "Database not available for agent registration"
@@ -2567,7 +2567,7 @@ class SessionIntelligenceEngine:
 
         try:
             # Check if agent already exists by name
-            existing_agent = await self.database.get_agent_by_name(name)
+            existing_agent = await self.database.get_agent_by_name(agent_name)
 
             now = datetime.now(UTC).isoformat()
 
@@ -2576,7 +2576,7 @@ class SessionIntelligenceEngine:
                 agent_id = existing_agent["id"]
                 agent_data = {
                     "id": agent_id,
-                    "name": name,
+                    "name": agent_name,
                     "agent_type": agent_type,
                     "display_name": (
                         display_name or
@@ -2611,19 +2611,19 @@ class SessionIntelligenceEngine:
                     "is_active": True,
                 }
                 await self.database.save_agent(agent_data)
-                debug_logger.info(f"Updated existing agent: {name} ({agent_id})")
+                debug_logger.info(f"Updated existing agent: {agent_name} ({agent_id})")
                 return AgentRegistrationResult(
                     agent_id=agent_id,
-                    name=name,
+                    name=agent_name,
                     status="updated",
-                    message=f"Agent '{name}' updated successfully",
+                    message=f"Agent '{agent_name}' updated successfully",
                 )
             else:
                 # Create new agent
                 agent_id = str(uuid.uuid4())
                 agent_data = {
                     "id": agent_id,
-                    "name": name,
+                    "name": agent_name,
                     "agent_type": agent_type,
                     "display_name": display_name,
                     "description": description,
@@ -2638,24 +2638,24 @@ class SessionIntelligenceEngine:
                     "is_active": True,
                 }
                 await self.database.save_agent(agent_data)
-                debug_logger.info(f"Created new agent: {name} ({agent_id})")
+                debug_logger.info(f"Created new agent: {agent_name} ({agent_id})")
                 return AgentRegistrationResult(
                     agent_id=agent_id,
-                    name=name,
+                    name=agent_name,
                     status="created",
-                    message=f"Agent '{name}' created successfully",
+                    message=f"Agent '{agent_name}' created successfully",
                 )
 
         except Exception as e:
-            debug_logger.error(f"Error registering agent {name}: {e}")
+            debug_logger.error(f"Error registering agent {agent_name}: {e}")
             return AgentRegistrationResult(
                 agent_id="",
-                name=name,
+                name=agent_name,
                 status="error",
                 message=f"Failed to register agent: {str(e)}",
             )
 
-    async def agent_get_info(self, identifier: str) -> Agent | None:
+    async def agent_get_info(self, agent_name: str) -> Agent | None:
         """
         Get agent information by name or UUID.
 
@@ -2663,7 +2663,7 @@ class SessionIntelligenceEngine:
         and queries accordingly.
 
         Args:
-            identifier: Agent name (e.g., "focused-quality-resolver") or
+            agent_name: Agent name (e.g., "focused-quality-resolver") or
                 UUID
 
         Returns:
@@ -2678,20 +2678,20 @@ class SessionIntelligenceEngine:
             # UUID format)
             is_uuid = False
             try:
-                uuid.UUID(identifier)
+                uuid.UUID(agent_name)
                 is_uuid = True
             except ValueError:
                 is_uuid = False
 
             if is_uuid:
-                agent_data = await self.database.get_agent(identifier)
+                agent_data = await self.database.get_agent(agent_name)
             else:
                 agent_data = await self.database.get_agent_by_name(
-                    identifier
+                    agent_name
                 )
 
             if not agent_data:
-                debug_logger.info(f"Agent not found: {identifier}")
+                debug_logger.info(f"Agent not found: {agent_name}")
                 return None
 
             # Convert timestamps to ISO strings if they're datetime objects
@@ -2735,7 +2735,7 @@ class SessionIntelligenceEngine:
             )
 
         except Exception as e:
-            debug_logger.error(f"Error getting agent {identifier}: {e}")
+            debug_logger.error(f"Error getting agent {agent_name}: {e}")
             return None
 
     async def agent_log_decision(

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -622,7 +622,7 @@ class LeanMCPInterface:
             "schema": {
                 "type": "object",
                 "properties": {
-                    "name": {
+                    "agent_name": {
                         "type": "string",
                         "description": "Unique agent name (e.g., 'focused-quality-resolver')",
                     },
@@ -650,17 +650,17 @@ class LeanMCPInterface:
                         "description": "List of agent capabilities",
                     },
                 },
-                "required": ["name", "agent_type"],
+                "required": ["agent_name", "agent_type"],
             },
             "examples": [
                 {
-                    "name": "focused-quality-resolver",
+                    "agent_name": "focused-quality-resolver",
                     "agent_type": "focused",
                     "display_name": "Quality Resolver",
                     "description": "Resolves code quality issues",
                     "capabilities": ["lint-fix", "format", "type-check"],
                 },
-                {"name": "micro-test-runner", "agent_type": "micro"},
+                {"agent_name": "micro-test-runner", "agent_type": "micro"},
             ],
         }
 
@@ -670,16 +670,16 @@ class LeanMCPInterface:
             "schema": {
                 "type": "object",
                 "properties": {
-                    "identifier": {
+                    "agent_name": {
                         "type": "string",
                         "description": "Agent name (e.g., 'focused-quality-resolver') or UUID",
                     }
                 },
-                "required": ["identifier"],
+                "required": ["agent_name"],
             },
             "examples": [
-                {"identifier": "focused-quality-resolver"},
-                {"identifier": "550e8400-e29b-41d4-a716-446655440000"},
+                {"agent_name": "focused-quality-resolver"},
+                {"agent_name": "550e8400-e29b-41d4-a716-446655440000"},
             ],
         }
 


### PR DESCRIPTION
## Summary

- Standardize all agent tool parameter naming to use `agent_name` consistently
- Fix `agent_register` param `name` -> `agent_name`
- Fix `agent_get_info` param `identifier` -> `agent_name`
- Add `target-branch: development` to dependabot config

## Test plan

- [x] Live tested agent_register with new `agent_name` param
- [x] Live tested agent_get_info with new `agent_name` param
- [x] Verified full write-read round trip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)