### PR TITLE
fix: coerce string parameters to dict in execute_tool

### DIFF
--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -1362,7 +1362,11 @@ class LeanMCPInterface:
                 try:
                     parameters = json.loads(parameters)
                 except (json.JSONDecodeError, TypeError) as e:
-                    return {"tool": tool_name, "status": "error", "error": f"Invalid parameters JSON: {e}"}
+                    return {
+                        "tool": tool_name,
+                        "status": "error",
+                        "error": f"Invalid parameters JSON: {e}",
+                    }
             if not isinstance(parameters, dict):
                 return {
                     "tool": tool_name,

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -16,6 +16,7 @@ Solution: Meta-Tool Pattern
 - Zero functionality loss with massive context savings
 """
 
+import json
 import logging
 from functools import wraps
 from typing import Any
@@ -1355,6 +1356,19 @@ class LeanMCPInterface:
 
             tool_info = self.tool_registry[tool_name]
             tool_func = tool_info["implementation"]
+
+            # Coerce JSON string parameters to dict (MCP proxies may serialize objects as strings)
+            if isinstance(parameters, str):
+                try:
+                    parameters = json.loads(parameters)
+                except (json.JSONDecodeError, TypeError) as e:
+                    return {"tool": tool_name, "status": "error", "error": f"Invalid parameters JSON: {e}"}
+            if not isinstance(parameters, dict):
+                return {
+                    "tool": tool_name,
+                    "status": "error",
+                    "error": f"parameters must be a mapping, got {type(parameters).__name__}",
+                }
 
             try:
                 # Execute tool - await if async, call directly if sync

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -746,7 +746,8 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
                     result = {"error": f"Invalid parameters JSON string for tool '{target}'"}
                     tool_params = None
             if tool_params is not None and not isinstance(tool_params, dict):
-                result = {"error": f"parameters must be a mapping, got {type(tool_params).__name__}"}
+                tp = type(tool_params).__name__
+                result = {"error": f"parameters must be a mapping, got {tp}"}
                 tool_params = None
             if tool_params is None:
                 pass  # result already set above

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -738,7 +738,19 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
         elif tool_name == "execute_tool":
             target = arguments.get("tool_name")
             tool_params = arguments.get("parameters", {})
-            if target not in tool_registry:
+            # Coerce JSON string parameters to dict (MCP proxies may serialize objects as strings)
+            if isinstance(tool_params, str):
+                try:
+                    tool_params = json.loads(tool_params)
+                except (json.JSONDecodeError, TypeError):
+                    result = {"error": f"Invalid parameters JSON string for tool '{target}'"}
+                    tool_params = None
+            if tool_params is not None and not isinstance(tool_params, dict):
+                result = {"error": f"parameters must be a mapping, got {type(tool_params).__name__}"}
+                tool_params = None
+            if tool_params is None:
+                pass  # result already set above
+            elif target not in tool_registry:
                 result = {
                     "error": f"Tool '{target}' not found",
                     "available_tools": list(tool_registry.keys()),


### PR DESCRIPTION
## Summary

- MCP proxies (lean proxy pattern) may serialize `parameters` as a JSON string instead of a dict/mapping
- This causes `TypeError: argument after ** must be a mapping, not str` in both dispatch points
- Added `json.loads()` coercion + type guards in `lean_mcp_interface.py` and `http_server.py`

## Test plan

- [x] 76 tests pass, 0 failures
- [x] Service restarted and verified with live `session_log_learning` calls
- [x] Invalid parameter types return clear error messages instead of crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)