### PR TITLE
feat: add session_recall for cross-session project knowledge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ sessions/
 metadata/
 agents/
 
+# Environment
+.env
+
 # Temporary files
 *.log
 *.tmp

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -2277,7 +2277,8 @@ class SessionIntelligenceEngine:
 
         Args:
             project_name: Project to recall knowledge for
-            include: Sections to include (default: all). Options: sessions, decisions, learnings, notebooks
+            include: Sections to include. Options: sessions, decisions,
+                learnings, notebooks (default: all)
             limit: Max items per section
             days: How far back to look
 

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -2261,6 +2261,69 @@ class SessionIntelligenceEngine:
             debug_logger.error(f"Error in session_query_notebooks: {e}")
             return []
 
+    async def session_recall(
+        self,
+        project_name: str,
+        include: list[str] | None = None,
+        limit: int = 10,
+        days: int = 30,
+    ) -> dict[str, Any]:
+        """
+        Recall project knowledge across all sessions.
+
+        Returns consolidated decisions, learnings, notebooks, and session history
+        for a project, regardless of which session created them. This solves the
+        problem of session ID changes on restart causing loss of recall.
+
+        Args:
+            project_name: Project to recall knowledge for
+            include: Sections to include (default: all). Options: sessions, decisions, learnings, notebooks
+            limit: Max items per section
+            days: How far back to look
+
+        Returns:
+            Consolidated project knowledge dict
+        """
+        debug_logger.info(f"Recalling project knowledge for: {project_name}")
+
+        if not self.database:
+            debug_logger.warning("No database configured for session_recall")
+            return {
+                "project_name": project_name,
+                "error": "No database configured",
+                "sessions": [],
+                "decisions": [],
+                "learnings": [],
+                "notebooks": [],
+                "counts": {"sessions": 0, "decisions": 0, "learnings": 0, "notebooks": 0},
+            }
+
+        try:
+            result = await self.database.recall_project(
+                project_name=project_name,
+                include=include,
+                limit=limit,
+                days=days,
+            )
+
+            debug_logger.info(
+                f"Recall for '{project_name}': "
+                f"{result.get('counts', {})}"
+            )
+            return result
+
+        except Exception as e:
+            debug_logger.error(f"Error in session_recall: {e}")
+            return {
+                "project_name": project_name,
+                "error": str(e),
+                "sessions": [],
+                "decisions": [],
+                "learnings": [],
+                "notebooks": [],
+                "counts": {"sessions": 0, "decisions": 0, "learnings": 0, "notebooks": 0},
+            }
+
     # ===== KNOWLEDGE SYSTEM =====
 
     def session_log_learning(

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -525,6 +525,40 @@ class LeanMCPInterface:
             ],
         }
 
+        registry["session_recall"] = {
+            "implementation": self._wrap_async_tool(self.session_engine.session_recall),
+            "description": "Recall project knowledge across all sessions - decisions, learnings, notebooks, history",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "project_name": {
+                        "type": "string",
+                        "description": "Project name to recall knowledge for",
+                    },
+                    "include": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["sessions", "decisions", "learnings", "notebooks"]},
+                        "description": "Sections to include (default: all)",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Max items per section",
+                    },
+                    "days": {
+                        "type": "integer",
+                        "default": 30,
+                        "description": "How far back to look in days",
+                    },
+                },
+                "required": ["project_name"],
+            },
+            "examples": [
+                {"project_name": "session-intelligence"},
+                {"project_name": "session-intelligence", "include": ["decisions", "learnings"], "limit": 5, "days": 7},
+            ],
+        }
+
         # ===== KNOWLEDGE SYSTEM TOOLS =====
 
         registry["session_log_learning"] = {

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -527,7 +527,7 @@ class LeanMCPInterface:
 
         registry["session_recall"] = {
             "implementation": self._wrap_async_tool(self.session_engine.session_recall),
-            "description": "Recall project knowledge across all sessions - decisions, learnings, notebooks, history",
+            "description": "Recall project knowledge across all sessions",
             "schema": {
                 "type": "object",
                 "properties": {
@@ -537,7 +537,10 @@ class LeanMCPInterface:
                     },
                     "include": {
                         "type": "array",
-                        "items": {"type": "string", "enum": ["sessions", "decisions", "learnings", "notebooks"]},
+                        "items": {
+                            "type": "string",
+                            "enum": ["sessions", "decisions", "learnings", "notebooks"],
+                        },
                         "description": "Sections to include (default: all)",
                     },
                     "limit": {
@@ -555,7 +558,12 @@ class LeanMCPInterface:
             },
             "examples": [
                 {"project_name": "session-intelligence"},
-                {"project_name": "session-intelligence", "include": ["decisions", "learnings"], "limit": 5, "days": 7},
+                {
+                    "project_name": "session-intelligence",
+                    "include": ["decisions", "learnings"],
+                    "limit": 5,
+                    "days": 7,
+                },
             ],
         }
 

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -874,6 +874,133 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
             return [self._from_record(row) for row in rows]
 
+    async def recall_project(
+        self,
+        project_name: str,
+        include: list[str] | None = None,
+        limit: int = 10,
+        days: int = 30,
+    ) -> dict[str, Any]:
+        """Recall recent sessions, decisions, learnings, and notebooks for a project."""
+        from datetime import UTC, datetime, timedelta
+
+        pool = self._ensure_connected()
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+        include_all = include is None
+        result: dict[str, Any] = {
+            "project_name": project_name,
+            "recall_window_days": days,
+            "sessions": [],
+            "decisions": [],
+            "learnings": [],
+            "notebooks": [],
+        }
+
+        async with pool.acquire() as conn:
+            if include_all or "sessions" in include:
+                rows = await conn.fetch(
+                    """
+                    SELECT id, started_at, ended_at, status, mode
+                    FROM sessions
+                    WHERE project_name = $1 AND started_at > $2
+                    ORDER BY started_at DESC
+                    LIMIT $3
+                    """,
+                    project_name,
+                    cutoff,
+                    limit,
+                )
+                result["sessions"] = [
+                    {
+                        "id": row["id"],
+                        "started_at": row["started_at"].isoformat() if row["started_at"] else None,
+                        "status": row["status"],
+                    }
+                    for row in rows
+                ]
+
+            if include_all or "decisions" in include:
+                rows = await conn.fetch(
+                    """
+                    SELECT d.id, d.description, d.category, d.rationale,
+                           d.impact_level, d.timestamp, s.id AS session_id
+                    FROM decisions d
+                    JOIN sessions s ON d.session_id = s.id
+                    WHERE s.project_name = $1 AND d.timestamp > $2
+                    ORDER BY d.timestamp DESC
+                    LIMIT $3
+                    """,
+                    project_name,
+                    cutoff,
+                    limit,
+                )
+                result["decisions"] = [
+                    {
+                        "description": row["description"],
+                        "category": row["category"],
+                        "rationale": row["rationale"],
+                        "timestamp": row["timestamp"].isoformat() if row["timestamp"] else None,
+                    }
+                    for row in rows
+                ]
+
+            if include_all or "learnings" in include:
+                path_row = await conn.fetchrow(
+                    """
+                    SELECT project_path FROM sessions
+                    WHERE project_name = $1 AND project_path IS NOT NULL
+                    LIMIT 1
+                    """,
+                    project_name,
+                )
+                if path_row:
+                    rows = await conn.fetch(
+                        """
+                        SELECT id, category, trigger_context, learning_content,
+                               source_session_id, success_count, failure_count,
+                               created_at, last_used
+                        FROM project_learnings
+                        WHERE project_path = $1
+                        ORDER BY success_count DESC, last_used DESC
+                        LIMIT $2
+                        """,
+                        path_row["project_path"],
+                        limit,
+                    )
+                    result["learnings"] = [self._from_record(row) for row in rows]
+
+            if include_all or "notebooks" in include:
+                rows = await conn.fetch(
+                    """
+                    SELECT ss.title, ss.tags, ss.created_at, ss.session_id
+                    FROM session_summaries ss
+                    JOIN sessions s ON ss.session_id = s.id
+                    WHERE s.project_name = $1 AND ss.created_at > $2
+                    ORDER BY ss.created_at DESC
+                    LIMIT $3
+                    """,
+                    project_name,
+                    cutoff,
+                    limit,
+                )
+                result["notebooks"] = [
+                    {
+                        "title": row["title"],
+                        "tags": row["tags"],
+                        "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+                        "session_id": row["session_id"],
+                    }
+                    for row in rows
+                ]
+
+        result["counts"] = {
+            "sessions": len(result["sessions"]),
+            "decisions": len(result["decisions"]),
+            "learnings": len(result["learnings"]),
+            "notebooks": len(result["notebooks"]),
+        }
+        return result
+
     # Agent execution operations
 
     async def save_agent_execution(self, execution_data: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

- Add `session_recall` tool that queries decisions, learnings, notebooks, and session history across ALL sessions for a given `project_name`
- Solves the problem of session ID changes on restart/clear causing loss of recall context
- Project identity (`project_name`) is the persistent key, not ephemeral `session_id`
- Also adds `.env` to `.gitignore`

## How it works

One call during session priming:
```python
session_recall(project_name="my-project", limit=5, days=30)
```

Returns consolidated view:
- **Sessions**: recent session IDs for continuity awareness
- **Decisions**: cross-session via `decisions JOIN sessions` on `project_name`
- **Learnings**: project-scoped (already were, now surfaced together)
- **Notebooks**: titles + tags without full content

## Test plan

- [x] Service restarts cleanly
- [x] `session_recall` returns data for projects with history
- [x] Empty results for projects with no history
- [ ] Hook integration tested on next session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)