### PR TITLE
fix: await async DB calls to prevent silent data loss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@v2.5.1
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@v2.8.0
     with:
       pixi-environment: "ci"
       python-versions: '["3.11", "3.12"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   ci:
-    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@v2.8.0
+    uses: Claire-s-Monster/ci-framework/.github/workflows/reusable-ci.yml@v2.5.1
     with:
       pixi-environment: "ci"
       python-versions: '["3.11", "3.12"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 ---
+# CI pipeline using ci-framework reusable workflow
 name: CI
 
 on:

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -949,7 +949,7 @@ class SessionIntelligenceEngine:
 
     # ===== DECISION LOGGING =====
 
-    def session_log_decision(
+    async def session_log_decision(
         self,
         decision: str,
         session_id: str | None = None,
@@ -964,9 +964,65 @@ class SessionIntelligenceEngine:
         Enhanced: Adds decision impact analysis and relationship mapping
         """
         try:
-            return self._log_decision_sync(
-                decision, session_id, context, impact_analysis,
-                link_artifacts
+            # Coerce context to dict if caller passed a string
+            if isinstance(context, str):
+                context = {"description": context}
+
+            decision_id = f"decision-{uuid.uuid4().hex[:8]}"
+
+            # Get current session
+            if not session_id and self.session_cache:
+                session_id = list(self.session_cache.keys())[-1]
+
+            # Update in-memory cache if session exists there
+            if session_id and session_id in self.session_cache:
+                session = self.session_cache[session_id]
+
+                from models.session_models import DecisionContext
+
+                decision_context = DecisionContext(
+                    session_id=session_id, project_state=context or {}
+                )
+
+                decision_obj = Decision(
+                    decision_id=decision_id,
+                    timestamp=datetime.now(UTC),
+                    description=decision,
+                    context=decision_context,
+                    impact_level=ImpactLevel.MEDIUM,
+                    artifacts=link_artifacts or [],
+                )
+
+                session.decisions.append(decision_obj)
+
+            # Always persist to database (not gated by session_cache)
+            if self.database:
+                decision_data = {
+                    "id": decision_id,
+                    "session_id": session_id or self._current_session_id,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "description": decision,
+                    "context": json.dumps(context or {}),
+                    "impact_level": "medium",
+                    "artifacts": json.dumps(link_artifacts or []),
+                }
+                await self.database.save_decision(decision_data)
+
+            # Impact analysis
+            impact_analysis_result = {}
+            if impact_analysis:
+                impact_analysis_result = {
+                    "estimated_impact": "medium",
+                    "affected_components": [],
+                    "risk_assessment": "low",
+                }
+
+            return DecisionResult(
+                decision_id=decision_id,
+                session_id=session_id or "unknown",
+                impact_analysis=impact_analysis_result,
+                linked_decisions=[],
+                predicted_outcomes=["Continue with planned execution"],
             )
         except Exception as e:
             return DecisionResult(
@@ -975,85 +1031,7 @@ class SessionIntelligenceEngine:
                 impact_analysis={"error": str(e)},
             )
 
-    def _log_decision_sync(
-        self,
-        decision: str,
-        session_id: str | None,
-        context: dict[str, Any] | str | None,
-        impact_analysis: bool,
-        link_artifacts: list[str] | None,
-    ) -> DecisionResult:
-        """Synchronous decision logging."""
-
-        # Coerce context to dict if caller passed a string
-        if isinstance(context, str):
-            context = {"description": context}
-
-        decision_id = f"decision-{uuid.uuid4().hex[:8]}"
-
-        # Get current session
-        if not session_id and self.session_cache:
-            session_id = list(self.session_cache.keys())[-1]
-
-        if session_id and session_id in self.session_cache:
-            session = self.session_cache[session_id]
-
-            from models.session_models import DecisionContext
-
-            decision_context = DecisionContext(
-                session_id=session_id, project_state=context or {}
-            )
-
-            decision_obj = Decision(
-                decision_id=decision_id,
-                timestamp=datetime.now(UTC),
-                description=decision,
-                context=decision_context,
-                impact_level=ImpactLevel.MEDIUM,
-                artifacts=link_artifacts or [],
-            )
-
-            session.decisions.append(decision_obj)
-
-            # Persist to database
-            if self.database:
-                decision_data = {
-                    "id": decision_id,
-                    "session_id": session_id,
-                    "timestamp": decision_obj.timestamp.isoformat(),
-                    "description": decision,
-                    "context": json.dumps(context or {}),
-                    "impact_level": decision_obj.impact_level.value,
-                    "artifacts": json.dumps(link_artifacts or []),
-                }
-                try:
-                    import asyncio
-
-                    asyncio.get_running_loop()
-                    asyncio.create_task(
-                        self.database.save_decision(decision_data)
-                    )
-                except RuntimeError:
-                    pass  # No event loop in sync context
-
-        # Impact analysis
-        impact_analysis_result = {}
-        if impact_analysis:
-            impact_analysis_result = {
-                "estimated_impact": "medium",
-                "affected_components": [],
-                "risk_assessment": "low",
-            }
-
-        return DecisionResult(
-            decision_id=decision_id,
-            session_id=session_id or "unknown",
-            impact_analysis=impact_analysis_result,
-            linked_decisions=[],
-            predicted_outcomes=["Continue with planned execution"],
-        )
-
-    def session_track_file_operation(
+    async def session_track_file_operation(
         self,
         operation: str,
         file_path: str,
@@ -1082,15 +1060,7 @@ class SessionIntelligenceEngine:
         }
 
         if self.database:
-            try:
-                import asyncio
-
-                asyncio.get_running_loop()
-                asyncio.create_task(
-                    self.database.save_file_operation(file_op_data)
-                )
-            except RuntimeError:
-                pass
+            await self.database.save_file_operation(file_op_data)
 
         return {
             "status": "success",
@@ -1282,7 +1252,7 @@ class SessionIntelligenceEngine:
 
     # ===== SESSION NOTEBOOK =====
 
-    def session_create_notebook(
+    async def session_create_notebook(
         self,
         session_id: str | None = None,
         title: str | None = None,
@@ -1313,7 +1283,7 @@ class SessionIntelligenceEngine:
             NotebookResult with generated notebook and file path
         """
         try:
-            return self._create_notebook_sync(
+            return await self._create_notebook_impl(
                 session_id,
                 title,
                 include_decisions,
@@ -1554,7 +1524,7 @@ class SessionIntelligenceEngine:
                 message=str(e),
             )
 
-    def _create_notebook_sync(
+    async def _create_notebook_impl(
         self,
         session_id: str | None,
         title: str | None,
@@ -1565,7 +1535,7 @@ class SessionIntelligenceEngine:
         save_to_file: bool,
         save_to_database: bool,
     ) -> NotebookResult:
-        """Synchronous notebook creation."""
+        """Notebook creation with proper async database access."""
 
         # Get session (current or specified)
         if not session_id:
@@ -1583,69 +1553,56 @@ class SessionIntelligenceEngine:
         # Merge decisions from database if available
         if self.database:
             try:
-                import asyncio
-
-                asyncio.get_running_loop()
-                asyncio.create_task(
-                    self.database.query_decisions_by_session(session_id)
-                )
-                # We can't await here in sync context, use alternative
-                # approach. Instead, check if we're in async context
-            except RuntimeError:
-                pass  # No event loop - skip database merge in sync context
-            else:
-                # If we have an event loop, schedule the merge
-                async def merge_db_decisions():
-                    db_decisions_list = (
-                        await self.database.query_decisions_by_session(
-                            session_id
-                        )
+                db_decisions_list = (
+                    await self.database.query_decisions_by_session(
+                        session_id
                     )
-                    existing_ids = {
-                        d.decision_id for d in session.decisions
-                    }
-                    for db_dec in db_decisions_list:
-                        dec_id = (
-                            db_dec.get("id")
-                            or db_dec.get("decision_id")
-                        )
-                        if dec_id and dec_id not in existing_ids:
-                            from models.session_models import Decision, DecisionContext
+                )
+                existing_ids = {
+                    d.decision_id for d in session.decisions
+                }
+                for db_dec in db_decisions_list:
+                    dec_id = (
+                        db_dec.get("id")
+                        or db_dec.get("decision_id")
+                    )
+                    if dec_id and dec_id not in existing_ids:
+                        from models.session_models import Decision, DecisionContext
 
-                            session.decisions.append(
-                                Decision(
-                                    decision_id=dec_id,
-                                    timestamp=(
-                                        safe_parse_datetime(
-                                            db_dec.get("timestamp")
-                                        )
-                                        or datetime.now(UTC)
-                                    ),
-                                    description=db_dec.get(
-                                        "description", ""
-                                    ),
-                                    context=DecisionContext(
-                                        session_id=session_id,
-                                        project_state={},
-                                    ),
-                                    impact_level=ImpactLevel(
-                                        db_dec.get(
-                                            "impact_level", "medium"
-                                        )
-                                    ),
-                                    artifacts=(
-                                        json.loads(
-                                            db_dec.get("artifacts", "[]")
-                                        )
-                                        if isinstance(
-                                            db_dec.get("artifacts"), str
-                                        )
-                                        else db_dec.get("artifacts", [])
-                                    ),
-                                )
+                        session.decisions.append(
+                            Decision(
+                                decision_id=dec_id,
+                                timestamp=(
+                                    safe_parse_datetime(
+                                        db_dec.get("timestamp")
+                                    )
+                                    or datetime.now(UTC)
+                                ),
+                                description=db_dec.get(
+                                    "description", ""
+                                ),
+                                context=DecisionContext(
+                                    session_id=session_id,
+                                    project_state={},
+                                ),
+                                impact_level=ImpactLevel(
+                                    db_dec.get(
+                                        "impact_level", "medium"
+                                    )
+                                ),
+                                artifacts=(
+                                    json.loads(
+                                        db_dec.get("artifacts", "[]")
+                                    )
+                                    if isinstance(
+                                        db_dec.get("artifacts"), str
+                                    )
+                                    else db_dec.get("artifacts", [])
+                                ),
                             )
-
-                asyncio.create_task(merge_db_decisions())
+                        )
+            except Exception as e:
+                debug_logger.error(f"Error merging DB decisions: {e}")
 
         # Calculate duration
         end_time = session.completed or datetime.now(UTC)
@@ -2327,7 +2284,7 @@ class SessionIntelligenceEngine:
 
     # ===== KNOWLEDGE SYSTEM =====
 
-    def session_log_learning(
+    async def session_log_learning(
         self,
         category: str,
         learning_content: str,
@@ -2371,63 +2328,33 @@ class SessionIntelligenceEngine:
             created_at=datetime.now().isoformat(),
         )
 
-        # Persist to database if available
+        # Persist to database
         status = "pending_save"
         message = f"Learning logged for {category}."
         if self.database:
             try:
-                import asyncio
-
                 # Validate source_session_id exists before FK insert
+                sid = None
                 if source_session:
-                    try:
-                        asyncio.get_running_loop()
+                    existing = await self.database.get_session(
+                        source_session
+                    )
+                    sid = source_session if existing else None
 
-                        async def _validate_and_save():
-                            existing = await self.database.get_session(
-                                source_session
-                            )
-                            sid = source_session if existing else None
-                            await self.database.save_project_learning(
-                                learning_id=learning_id,
-                                project_path=effective_project,
-                                category=(
-                                    category.value
-                                    if hasattr(category, "value")
-                                    else category
-                                ),
-                                learning_content=learning_content,
-                                trigger_context=trigger_context,
-                                source_session_id=sid,
-                            )
-
-                        asyncio.create_task(_validate_and_save())
-                        status = "saved"
-                        message = f"Learning saved to database for {category}."
-                    except RuntimeError:
-                        # No event loop - can't validate session
-                        pass
-                else:
-                    try:
-                        asyncio.get_running_loop()
-                        asyncio.create_task(
-                            self.database.save_project_learning(
-                                learning_id=learning_id,
-                                project_path=effective_project,
-                                category=(
-                                    category.value
-                                    if hasattr(category, "value")
-                                    else category
-                                ),
-                                learning_content=learning_content,
-                                trigger_context=trigger_context,
-                                source_session_id=None,
-                            )
-                        )
-                        status = "saved"
-                        message = f"Learning saved to database for {category}."
-                    except RuntimeError:
-                        pass  # No event loop in sync context
+                await self.database.save_project_learning(
+                    learning_id=learning_id,
+                    project_path=effective_project,
+                    category=(
+                        category.value
+                        if hasattr(category, "value")
+                        else category
+                    ),
+                    learning_content=learning_content,
+                    trigger_context=trigger_context,
+                    source_session_id=sid,
+                )
+                status = "saved"
+                message = f"Learning saved to database for {category}."
             except Exception as e:
                 debug_logger.error(f"Error saving learning to database: {e}")
                 message += f" Database save failed: {e}"
@@ -2533,7 +2460,7 @@ class SessionIntelligenceEngine:
                 universal_count=0,
             )
 
-    def session_update_solution_outcome(
+    async def session_update_solution_outcome(
         self,
         solution_id: str,
         success: bool,
@@ -2557,22 +2484,15 @@ class SessionIntelligenceEngine:
         message = "Solution outcome recorded."
         if self.database:
             try:
-                import asyncio
-
-                asyncio.get_running_loop()
-                asyncio.create_task(
-                    self.database.update_solution_outcome(
-                        solution_id=solution_id,
-                        success=success,
-                    )
+                await self.database.update_solution_outcome(
+                    solution_id=solution_id,
+                    success=success,
                 )
                 status = "updated"
                 message = (
                     f"Solution outcome updated: "
                     f"{'success' if success else 'failure'}."
                 )
-            except RuntimeError:
-                pass  # No event loop in sync context
             except Exception as e:
                 debug_logger.error(
                     f"Error updating solution outcome: {e}"

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -190,7 +190,9 @@ class LeanMCPInterface:
         }
 
         registry["session_track_file_operation"] = {
-            "implementation": self._wrap_async_tool(self.session_engine.session_track_file_operation),
+            "implementation": self._wrap_async_tool(
+                self.session_engine.session_track_file_operation
+            ),
             "description": "Track file create/edit/delete operations for session notebook",
             "schema": {
                 "type": "object",
@@ -638,7 +640,9 @@ class LeanMCPInterface:
         }
 
         registry["session_update_solution_outcome"] = {
-            "implementation": self._wrap_async_tool(self.session_engine.session_update_solution_outcome),
+            "implementation": self._wrap_async_tool(
+                self.session_engine.session_update_solution_outcome
+            ),
             "description": "Update success/failure count for a solution after trying it",
             "schema": {
                 "type": "object",

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -160,7 +160,7 @@ class LeanMCPInterface:
         }
 
         registry["session_log_decision"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_log_decision),
+            "implementation": self._wrap_async_tool(self.session_engine.session_log_decision),
             "description": "Log decisions with context and impact analysis",
             "schema": {
                 "type": "object",
@@ -190,7 +190,7 @@ class LeanMCPInterface:
         }
 
         registry["session_track_file_operation"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_track_file_operation),
+            "implementation": self._wrap_async_tool(self.session_engine.session_track_file_operation),
             "description": "Track file create/edit/delete operations for session notebook",
             "schema": {
                 "type": "object",
@@ -570,7 +570,7 @@ class LeanMCPInterface:
         # ===== KNOWLEDGE SYSTEM TOOLS =====
 
         registry["session_log_learning"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_log_learning),
+            "implementation": self._wrap_async_tool(self.session_engine.session_log_learning),
             "description": "Log a project-specific learning (pattern, fix, preference, workflow)",
             "schema": {
                 "type": "object",
@@ -638,7 +638,7 @@ class LeanMCPInterface:
         }
 
         registry["session_update_solution_outcome"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_update_solution_outcome),
+            "implementation": self._wrap_async_tool(self.session_engine.session_update_solution_outcome),
             "description": "Update success/failure count for a solution after trying it",
             "schema": {
                 "type": "object",

--- a/tests/unit/test_knowledge_system.py
+++ b/tests/unit/test_knowledge_system.py
@@ -67,9 +67,10 @@ def engine_with_db(tmp_path, mock_database):
 class TestSessionLogLearning:
     """Tests for session_log_learning method."""
 
-    def test_returns_learning_result(self, engine):
+    @pytest.mark.asyncio
+    async def test_returns_learning_result(self, engine):
         """Returns a LearningResult with correct fields."""
-        result = engine.session_log_learning(
+        result = await engine.session_log_learning(
             category="pattern",
             learning_content="Use fixtures for test data",
         )
@@ -80,9 +81,10 @@ class TestSessionLogLearning:
         assert result.learning.learning_content == "Use fixtures for test data"
         assert result.learning.category == LearningCategory.PATTERN
 
-    def test_without_database_returns_pending(self, engine):
+    @pytest.mark.asyncio
+    async def test_without_database_returns_pending(self, engine):
         """Without a database, status should be pending_save."""
-        result = engine.session_log_learning(
+        result = await engine.session_log_learning(
             category="error_fix",
             learning_content="Fix import errors with sys.path",
         )
@@ -94,7 +96,7 @@ class TestSessionLogLearning:
         self, engine_with_db, mock_database
     ):
         """With a database and running event loop, status is 'saved'."""
-        result = engine_with_db.session_log_learning(
+        result = await engine_with_db.session_log_learning(
             category="workflow",
             learning_content="Run lint before commit",
         )
@@ -106,9 +108,10 @@ class TestSessionLogLearning:
         await asyncio.sleep(0)
         mock_database.save_project_learning.assert_called_once()
 
-    def test_learning_content_preserved(self, engine):
+    @pytest.mark.asyncio
+    async def test_learning_content_preserved(self, engine):
         """Learning content and trigger context are preserved."""
-        result = engine.session_log_learning(
+        result = await engine.session_log_learning(
             category="pattern",
             learning_content="Validate FK references before insert",
             trigger_context="Database FK violation encountered",
@@ -117,9 +120,10 @@ class TestSessionLogLearning:
         assert result.learning.learning_content == "Validate FK references before insert"
         assert result.learning.trigger_context == "Database FK violation encountered"
 
-    def test_project_path_defaults_to_repository(self, engine):
+    @pytest.mark.asyncio
+    async def test_project_path_defaults_to_repository(self, engine):
         """Project path defaults to engine's repository path."""
-        result = engine.session_log_learning(
+        result = await engine.session_log_learning(
             category="preference",
             learning_content="Use ruff for linting",
         )
@@ -127,9 +131,10 @@ class TestSessionLogLearning:
         assert result.learning.project_path is not None
         assert len(result.learning.project_path) > 0
 
-    def test_custom_project_path(self, engine):
+    @pytest.mark.asyncio
+    async def test_custom_project_path(self, engine):
         """Custom project path overrides default."""
-        result = engine.session_log_learning(
+        result = await engine.session_log_learning(
             category="workflow",
             learning_content="Use TDD workflow",
             project_path="/custom/project",
@@ -137,28 +142,31 @@ class TestSessionLogLearning:
 
         assert result.learning.project_path == "/custom/project"
 
-    def test_all_categories_accepted(self, engine):
+    @pytest.mark.asyncio
+    async def test_all_categories_accepted(self, engine):
         """All learning categories are accepted."""
         for cat in ["error_fix", "pattern", "preference", "workflow"]:
-            result = engine.session_log_learning(
+            result = await engine.session_log_learning(
                 category=cat,
                 learning_content=f"Test learning for {cat}",
             )
             assert result.learning.category == LearningCategory(cat)
 
-    def test_invalid_category_raises(self, engine):
+    @pytest.mark.asyncio
+    async def test_invalid_category_raises(self, engine):
         """Invalid category raises ValueError."""
         with pytest.raises(ValueError):
-            engine.session_log_learning(
+            await engine.session_log_learning(
                 category="invalid_category",
                 learning_content="This should fail",
             )
 
-    def test_unique_ids(self, engine):
+    @pytest.mark.asyncio
+    async def test_unique_ids(self, engine):
         """Each call generates a unique learning ID."""
         ids = set()
         for _ in range(10):
-            result = engine.session_log_learning(
+            result = await engine.session_log_learning(
                 category="pattern",
                 learning_content="Repeated learning",
             )
@@ -173,7 +181,7 @@ class TestSessionLogLearning:
         """Without active session, source_session_id is None in save call."""
         assert engine_with_db._current_session_id is None
 
-        result = engine_with_db.session_log_learning(
+        result = await engine_with_db.session_log_learning(
             category="pattern",
             learning_content="No session learning",
         )
@@ -194,7 +202,7 @@ class TestSessionLogLearning:
         engine_with_db._current_session_id = "sess_123"
         mock_database.get_session = AsyncMock(return_value={"id": "sess_123"})
 
-        result = engine_with_db.session_log_learning(
+        result = await engine_with_db.session_log_learning(
             category="workflow",
             learning_content="Session-linked learning",
         )
@@ -216,7 +224,7 @@ class TestSessionLogLearning:
         engine_with_db._current_session_id = "nonexistent_session"
         mock_database.get_session = AsyncMock(return_value=None)
 
-        result = engine_with_db.session_log_learning(
+        result = await engine_with_db.session_log_learning(
             category="pattern",
             learning_content="Orphan session learning",
         )
@@ -233,7 +241,7 @@ class TestSessionLogLearning:
         self, engine_with_db, mock_database
     ):
         """Category enum value (not enum object) is passed to database."""
-        engine_with_db.session_log_learning(
+        await engine_with_db.session_log_learning(
             category="error_fix",
             learning_content="Test category extraction",
         )
@@ -433,9 +441,10 @@ class TestSessionFindSolution:
 class TestSessionUpdateSolutionOutcome:
     """Tests for session_update_solution_outcome method."""
 
-    def test_without_database_returns_pending(self, engine):
+    @pytest.mark.asyncio
+    async def test_without_database_returns_pending(self, engine):
         """Without database, returns pending_update status."""
-        result = engine.session_update_solution_outcome(
+        result = await engine.session_update_solution_outcome(
             solution_id="sol_123",
             success=True,
         )
@@ -447,7 +456,7 @@ class TestSessionUpdateSolutionOutcome:
     @pytest.mark.asyncio
     async def test_with_database_returns_updated(self, engine_with_db):
         """With database and event loop, returns updated status."""
-        result = engine_with_db.session_update_solution_outcome(
+        result = await engine_with_db.session_update_solution_outcome(
             solution_id="sol_456",
             success=True,
         )
@@ -458,7 +467,7 @@ class TestSessionUpdateSolutionOutcome:
     @pytest.mark.asyncio
     async def test_failure_outcome_message(self, engine_with_db):
         """Failure outcome is reflected in message."""
-        result = engine_with_db.session_update_solution_outcome(
+        result = await engine_with_db.session_update_solution_outcome(
             solution_id="sol_789",
             success=False,
         )
@@ -466,9 +475,10 @@ class TestSessionUpdateSolutionOutcome:
         assert result.status == "updated"
         assert "failure" in result.message.lower()
 
-    def test_preserves_solution_id(self, engine):
+    @pytest.mark.asyncio
+    async def test_preserves_solution_id(self, engine):
         """Solution ID is preserved in result."""
-        result = engine.session_update_solution_outcome(
+        result = await engine.session_update_solution_outcome(
             solution_id="my_solution_id",
             success=True,
         )
@@ -478,7 +488,7 @@ class TestSessionUpdateSolutionOutcome:
     @pytest.mark.asyncio
     async def test_calls_database_update(self, engine_with_db, mock_database):
         """Verifies database.update_solution_outcome is called."""
-        engine_with_db.session_update_solution_outcome(
+        await engine_with_db.session_update_solution_outcome(
             solution_id="sol_abc",
             success=True,
         )
@@ -507,7 +517,7 @@ class TestOriginalBugDetection:
     @pytest.mark.asyncio
     async def test_learning_not_permanently_pending(self, engine_with_db):
         """Learning must not remain in 'pending_save' when DB is available."""
-        result = engine_with_db.session_log_learning(
+        result = await engine_with_db.session_log_learning(
             category="pattern",
             learning_content="Test content",
         )
@@ -549,7 +559,7 @@ class TestOriginalBugDetection:
     @pytest.mark.asyncio
     async def test_outcome_not_permanently_pending(self, engine_with_db):
         """Outcome must not remain in 'pending_update' when DB is available."""
-        result = engine_with_db.session_update_solution_outcome(
+        result = await engine_with_db.session_update_solution_outcome(
             solution_id="sol_1",
             success=True,
         )


### PR DESCRIPTION
## Summary

- **Root cause**: 7 instances of `asyncio.create_task()` fire-and-forget in sync methods. Database write tasks were never awaited and could be garbage collected before completing. All persistence calls returned "success" while silently dropping data.
- **Secondary bug**: `session_log_decision` gated ALL database persistence on `session_id in self.session_cache`, so decisions were silently dropped whenever the session wasn't in the in-memory cache.
- Converted 5 methods from sync to async with proper `await` on database calls
- Updated `lean_mcp_interface.py` to use `_wrap_async_tool` for affected methods

## Affected Methods

| Method | Issue |
|--------|-------|
| `session_log_decision` | Fire-and-forget + gated by session_cache |
| `session_log_learning` | Fire-and-forget (2 code paths) |
| `session_track_file_operation` | Fire-and-forget |
| `session_update_solution_outcome` | Fire-and-forget |
| `_create_notebook_sync` → `_create_notebook_impl` | Fire-and-forget DB reads (2 instances) |

## Test plan

- [ ] Restart session-intelligence service
- [ ] Call `session_log_decision` and verify it persists (query returns results)
- [ ] Call `session_log_learning` and verify it persists (query returns results)
- [ ] Call `session_update_solution_outcome` and verify persistence
- [ ] Verify `session_track_file_operation` persists
- [ ] Verify notebook generation includes DB-persisted decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)