### PR TITLE
fix: pass datetime objects to asyncpg instead of isoformat strings

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -1000,7 +1000,7 @@ class SessionIntelligenceEngine:
                 decision_data = {
                     "id": decision_id,
                     "session_id": session_id or self._current_session_id,
-                    "timestamp": datetime.now(UTC).isoformat(),
+                    "timestamp": datetime.now(UTC),
                     "description": decision,
                     "context": json.dumps(context or {}),
                     "impact_level": "medium",
@@ -1050,7 +1050,7 @@ class SessionIntelligenceEngine:
 
         file_op_data = {
             "session_id": session_id,
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(UTC),
             "operation": operation,
             "file_path": file_path,
             "lines_added": lines_added,
@@ -1503,7 +1503,7 @@ class SessionIntelligenceEngine:
                         "summary_markdown": summary_markdown,
                         "key_changes": key_changes,
                         "tags": tags,
-                        "created_at": datetime.now(UTC).isoformat(),
+                        "created_at": datetime.now(UTC),
                     }
                 )
 
@@ -2553,7 +2553,7 @@ class SessionIntelligenceEngine:
             # Check if agent already exists by name
             existing_agent = await self.database.get_agent_by_name(agent_name)
 
-            now = datetime.now(UTC).isoformat()
+            now = datetime.now(UTC)
 
             if existing_agent:
                 # Update existing agent
@@ -2780,7 +2780,7 @@ class SessionIntelligenceEngine:
 
             agent_id = agent_data["id"]
             decision_id = str(uuid.uuid4())
-            now = datetime.now(UTC).isoformat()
+            now = datetime.now(UTC)
 
             # Build decision data for database
             decision_data = {
@@ -3047,7 +3047,7 @@ class SessionIntelligenceEngine:
 
             agent_id = agent_data["id"]
             learning_id = str(uuid.uuid4())
-            now = datetime.now(UTC).isoformat()
+            now = datetime.now(UTC)
 
             # Build learning data for database
             learning_data = {
@@ -3347,7 +3347,7 @@ class SessionIntelligenceEngine:
 
             agent_id = agent_data["id"]
             notebook_id = str(uuid.uuid4())
-            now = datetime.now(UTC).isoformat()
+            now = datetime.now(UTC)
 
             # Build notebook data for database
             notebook_data = {


### PR DESCRIPTION
## Summary

Follows up on #12 (async-await fix). The await fix made errors visible instead of silently swallowed, revealing that **all 7 database write sites** were passing `.isoformat()` strings where asyncpg expects `datetime` objects for TIMESTAMPTZ columns.

Every `save_decision`, `save_agent`, `save_agent_decision`, `save_agent_learning`, `save_agent_notebook`, `save_session_summary`, and `save_file_operation` call was failing with:
```
invalid input for query argument: expected datetime, got 'str'
```

This means the server has been silently dropping ALL persistence data since deployment — first due to fire-and-forget tasks (#12), then due to type mismatch (this PR).

## Fixed sites (7)

| Method | Field(s) |
|--------|----------|
| `session_log_decision` | timestamp |
| `session_track_file_operation` | timestamp |
| `session_create_notebook` | created_at |
| `agent_register` | first_seen_at, last_active_at |
| `agent_log_decision` | timestamp |
| `agent_log_learning` | created_at, updated_at |
| `agent_create_notebook` | created_at, updated_at |

## Test plan

- [ ] Merge, restart service
- [ ] `session_log_decision` — verify no error in result, then query back via `session_recall`
- [ ] `session_log_learning` — verify persists and appears in `session_recall`
- [ ] `agent_register` + `agent_log_decision` — verify agent data persists
- [ ] Confirm old learnings (from before the bug) still query correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)