### PR TITLE
fix: persist sessions to DB and handle NULL session_id in decisions

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -997,9 +997,14 @@ class SessionIntelligenceEngine:
 
             # Always persist to database (not gated by session_cache)
             if self.database:
+                effective_session_id = (
+                    session_id
+                    or self._current_session_id
+                    or self._get_or_create_current_session_id()
+                )
                 decision_data = {
                     "id": decision_id,
-                    "session_id": session_id or self._current_session_id,
+                    "session_id": effective_session_id,
                     "timestamp": datetime.now(UTC),
                     "description": decision,
                     "context": json.dumps(context or {}),

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -285,7 +285,7 @@ class SessionIntelligenceEngine:
 
     # ===== SESSION LIFECYCLE MANAGEMENT =====
 
-    def session_manage_lifecycle(
+    async def session_manage_lifecycle(
         self,
         operation: str,
         mode: str = "local",
@@ -304,7 +304,7 @@ class SessionIntelligenceEngine:
             claudecode_capture_enhanced_state
         """
         try:
-            return self._manage_lifecycle_sync(
+            return await self._manage_lifecycle_impl(
                 operation, mode, project_name, metadata, auto_recovery
             )
         except Exception as e:
@@ -315,7 +315,7 @@ class SessionIntelligenceEngine:
                 message=f"Session lifecycle error: {str(e)}",
             )
 
-    def _manage_lifecycle_sync(
+    async def _manage_lifecycle_impl(
         self,
         operation: str,
         mode: str,
@@ -323,10 +323,23 @@ class SessionIntelligenceEngine:
         metadata: dict[str, Any] | None,
         auto_recovery: bool,
     ) -> SessionResult:
-        """Synchronous session lifecycle management."""
+        """Session lifecycle management."""
 
         if operation == "create":
-            return self._create_session(mode, project_name, metadata or {})
+            result = self._create_session(
+                mode, project_name, metadata or {}
+            )
+            # Persist session to DB so FK references work
+            if result.status == "success" and self.database:
+                try:
+                    await self.database.save_session(
+                        result.session_data.model_dump(mode="python")
+                    )
+                except Exception as e:
+                    debug_logger.error(
+                        f"Error persisting session to DB: {e}"
+                    )
+            return result
         elif operation == "resume":
             return self._resume_session(auto_recovery)
         elif operation == "finalize":
@@ -1000,8 +1013,25 @@ class SessionIntelligenceEngine:
                 effective_session_id = (
                     session_id
                     or self._current_session_id
-                    or self._get_or_create_current_session_id()
                 )
+                # Auto-create and persist session if needed
+                if not effective_session_id:
+                    effective_session_id = (
+                        self._get_or_create_current_session_id()
+                    )
+                    if effective_session_id and self.database:
+                        session = self.session_cache.get(
+                            effective_session_id
+                        )
+                        if session:
+                            try:
+                                await self.database.save_session(
+                                    session.model_dump(
+                                        mode="python"
+                                    )
+                                )
+                            except Exception:
+                                pass  # Best-effort
                 decision_data = {
                     "id": decision_id,
                     "session_id": effective_session_id,

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -64,7 +64,7 @@ class LeanMCPInterface:
 
         # Session Management Tools
         registry["session_manage_lifecycle"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_manage_lifecycle),
+            "implementation": self._wrap_async_tool(self.session_engine.session_manage_lifecycle),
             "description": "Complete session lifecycle management with recovery",
             "schema": {
                 "type": "object",


### PR DESCRIPTION
## Summary

Bugs #3 and #4 in the persistence chain (after #12 async-await and #13 datetime types).

**Bug 3 — NULL session_id**: `session_log_decision` fails with NOT NULL constraint when called before `session_manage_lifecycle("create")`. Fixed by using `_get_or_create_current_session_id()` fallback.

**Bug 4 — Session not in DB**: `_create_session` only stored sessions in memory/filesystem, never in the database. The `decisions` table has `REFERENCES sessions(id)`, so every decision INSERT failed with FK violation. Fixed by persisting to DB in `session_manage_lifecycle` and in `session_log_decision`'s auto-create fallback.

Also makes `session_manage_lifecycle` async (registered with `_wrap_async_tool`).

## The full persistence bug chain

| # | Bug | PR | Status |
|---|-----|-----|--------|
| 1 | Fire-and-forget `create_task` | #12 | Merged |
| 2 | `.isoformat()` strings vs `datetime` objects | #13 | Merged |
| 3 | NULL `session_id` on decisions | #14 | This PR |
| 4 | Sessions never persisted to DB (FK violation) | #14 | This PR |

## Test plan

- [ ] Merge, restart service
- [ ] Call `session_log_decision` WITHOUT prior `session_manage_lifecycle` — should auto-create session and persist
- [ ] Call `session_log_decision` WITH active session — should work
- [ ] Verify decisions appear in `session_recall`
- [ ] Verify `session_manage_lifecycle("create")` persists session to DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)