### PR TITLE
fix: session_search learnings backend queries

### DIFF
--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -2016,54 +2016,96 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
         Args:
             query: Search query string
-            search_type: Type of search - "fulltext", "tag", or "file" (only fulltext supported)
+            search_type: Type of search - "fulltext", "tag", "file", or "learnings"
             limit: Maximum results to return
 
         Returns:
-            List of dicts with session_id, title, summary, tags, relevance, snippet
+            List of dicts with session_id, title, snippet, relevance, project_name,
+            project_path, started_at, tags
         """
         pool = self._ensure_connected()
 
         async with pool.acquire() as conn:
-            # PostgreSQL full-text search using to_tsvector and plainto_tsquery
-            # Search in both title and summary_markdown fields
-            # JOIN with sessions table to avoid N+1 query pattern
-            rows = await conn.fetch(
-                """
-                SELECT
-                    ss.session_id,
-                    ss.title,
-                    ss.summary_markdown as summary,
-                    ss.tags,
-                    ss.created_at,
-                    s.project_name,
-                    s.project_path,
-                    s.started_at,
-                    ts_rank(
-                        to_tsvector(
+            if search_type == "learnings":
+                # Search project_learnings table using PostgreSQL FTS
+                rows = await conn.fetch(
+                    """
+                    SELECT
+                        id as session_id,
+                        category as title,
+                        ts_headline(
+                            'english',
+                            coalesce(learning_content, ''),
+                            plainto_tsquery('english', $1),
+                            'MaxWords=50, MinWords=25, MaxFragments=1'
+                        ) as snippet,
+                        ts_rank(
+                            to_tsvector(
+                                'english',
+                                coalesce(category, '') || ' ' ||
+                                coalesce(trigger_context, '') || ' ' ||
+                                coalesce(learning_content, '')
+                            ),
+                            plainto_tsquery('english', $1)
+                        ) as relevance,
+                        NULL::text as project_name,
+                        project_path,
+                        created_at as started_at,
+                        '[]'::jsonb as tags
+                    FROM project_learnings
+                    WHERE to_tsvector(
+                            'english',
+                            coalesce(category, '') || ' ' ||
+                            coalesce(trigger_context, '') || ' ' ||
+                            coalesce(learning_content, '')
+                          )
+                          @@ plainto_tsquery('english', $1)
+                    ORDER BY relevance DESC
+                    LIMIT $2
+                    """,
+                    query,
+                    limit,
+                )
+            else:
+                # PostgreSQL full-text search using to_tsvector and plainto_tsquery
+                # Search in both title and summary_markdown fields
+                # JOIN with sessions table to avoid N+1 query pattern
+                rows = await conn.fetch(
+                    """
+                    SELECT
+                        ss.session_id,
+                        ss.title,
+                        ss.summary_markdown as summary,
+                        ss.tags,
+                        ss.created_at,
+                        s.project_name,
+                        s.project_path,
+                        s.started_at,
+                        ts_rank(
+                            to_tsvector(
+                                'english',
+                                coalesce(ss.title, '') || ' ' || coalesce(ss.summary_markdown, '')
+                            ),
+                            plainto_tsquery('english', $1)
+                        ) as relevance,
+                        ts_headline(
+                            'english',
+                            coalesce(ss.summary_markdown, ''),
+                            plainto_tsquery('english', $1),
+                            'MaxWords=50, MinWords=25, MaxFragments=1'
+                        ) as snippet
+                    FROM session_summaries ss
+                    JOIN sessions s ON ss.session_id = s.id
+                    WHERE to_tsvector(
                             'english',
                             coalesce(ss.title, '') || ' ' || coalesce(ss.summary_markdown, '')
-                        ),
-                        plainto_tsquery('english', $1)
-                    ) as relevance,
-                    ts_headline(
-                        'english',
-                        coalesce(ss.summary_markdown, ''),
-                        plainto_tsquery('english', $1),
-                        'MaxWords=50, MinWords=25, MaxFragments=1'
-                    ) as snippet
-                FROM session_summaries ss
-                JOIN sessions s ON ss.session_id = s.id
-                WHERE to_tsvector(
-                        'english',
-                        coalesce(ss.title, '') || ' ' || coalesce(ss.summary_markdown, '')
-                      )
-                      @@ plainto_tsquery('english', $1)
-                ORDER BY relevance DESC
-                LIMIT $2
-                """,
-                query,
-                limit,
-            )
+                          )
+                          @@ plainto_tsquery('english', $1)
+                    ORDER BY relevance DESC
+                    LIMIT $2
+                    """,
+                    query,
+                    limit,
+                )
 
         return [dict(row) for row in rows]

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -1295,9 +1295,35 @@ class SQLiteBackend(BaseDatabaseBackend):
         )
         await conn.commit()
 
-    async def search_sessions(self, query: str, limit: int = 20) -> list[dict[str, Any]]:
-        """Full-text search across sessions."""
+    async def search_sessions(
+        self, query: str, search_type: str = "fulltext", limit: int = 20
+    ) -> list[dict[str, Any]]:
+        """Full-text search across sessions or learnings."""
         conn = self._ensure_connected()
+
+        if search_type == "learnings":
+            # Search project_learnings table using LIKE pattern matching
+            pattern = f"%{query}%"
+            cursor = await conn.execute(
+                """
+                SELECT
+                    id as session_id,
+                    category as title,
+                    learning_content as snippet,
+                    NULL as relevance,
+                    NULL as project_name,
+                    project_path,
+                    created_at as started_at,
+                    '[]' as tags
+                FROM project_learnings
+                WHERE learning_content LIKE ? OR trigger_context LIKE ? OR category LIKE ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (pattern, pattern, pattern, limit),
+            )
+            rows = await cursor.fetchall()
+            return [dict(row) for row in rows]
 
         # Use FTS5 MATCH syntax for full-text search
         # JOIN with sessions table to avoid N+1 query pattern


### PR DESCRIPTION
## Summary
- Both PostgreSQL and SQLite `search_sessions()` ignored `search_type` parameter — always searched `session_summaries`
- `search_type="learnings"` now correctly queries `project_learnings` table
- PostgreSQL uses `to_tsvector`/`plainto_tsquery` FTS
- SQLite uses `LIKE`-based search

## Test plan
- [x] 388 passed, 1 skipped, 0 failures (full suite with PostgreSQL)
- [x] Live-tested: `session_search(search_type="learnings", query="pytest asyncio")` returns 5 results (was 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)