### PR TITLE
feat: add search_type='decisions' for cross-project decision retrieval

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -2216,7 +2216,7 @@ class SessionIntelligenceEngine:
                         session_id=result.get("session_id", ""),
                         title=result.get("title"),
                         snippet=result.get("snippet", ""),
-                        relevance=float(result.get("relevance", 0.0)),
+                        relevance=float(result.get("relevance") or 0.0),
                         project_name=result.get("project_name"),
                         project_path=result.get("project_path"),
                         started_at=started_at,

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -488,9 +488,12 @@ class LeanMCPInterface:
                     },
                     "search_type": {
                         "type": "string",
-                        "enum": ["fulltext", "tag", "file"],
+                        "enum": ["fulltext", "tag", "file", "learnings", "decisions"],
                         "default": "fulltext",
-                        "description": "Type of search to perform",
+                        "description": (
+                            "Type of search to perform. 'decisions' and "
+                            "'learnings' search across all projects (cross-project)."
+                        ),
                     },
                     "limit": {
                         "type": "integer",

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -2016,7 +2016,8 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
         Args:
             query: Search query string
-            search_type: Type of search - "fulltext", "tag", "file", or "learnings"
+            search_type: Type of search - "fulltext", "tag", "file", "learnings",
+                or "decisions"
             limit: Maximum results to return
 
         Returns:
@@ -2026,7 +2027,49 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         pool = self._ensure_connected()
 
         async with pool.acquire() as conn:
-            if search_type == "learnings":
+            if search_type == "decisions":
+                # Search decisions table cross-project using PostgreSQL FTS.
+                # JOIN with sessions to surface project_name/project_path.
+                rows = await conn.fetch(
+                    """
+                    SELECT
+                        d.id as session_id,
+                        d.category as title,
+                        ts_headline(
+                            'english',
+                            coalesce(d.description, ''),
+                            plainto_tsquery('english', $1),
+                            'MaxWords=50, MinWords=25, MaxFragments=1'
+                        ) as snippet,
+                        ts_rank(
+                            to_tsvector(
+                                'english',
+                                coalesce(d.category, '') || ' ' ||
+                                coalesce(d.description, '') || ' ' ||
+                                coalesce(d.rationale, '')
+                            ),
+                            plainto_tsquery('english', $1)
+                        ) as relevance,
+                        s.project_name,
+                        s.project_path,
+                        d.timestamp as started_at,
+                        '[]'::jsonb as tags
+                    FROM decisions d
+                    JOIN sessions s ON d.session_id = s.id
+                    WHERE to_tsvector(
+                            'english',
+                            coalesce(d.category, '') || ' ' ||
+                            coalesce(d.description, '') || ' ' ||
+                            coalesce(d.rationale, '')
+                          )
+                          @@ plainto_tsquery('english', $1)
+                    ORDER BY relevance DESC
+                    LIMIT $2
+                    """,
+                    query,
+                    limit,
+                )
+            elif search_type == "learnings":
                 # Search project_learnings table using PostgreSQL FTS
                 rows = await conn.fetch(
                     """

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -1301,6 +1301,32 @@ class SQLiteBackend(BaseDatabaseBackend):
         """Full-text search across sessions or learnings."""
         conn = self._ensure_connected()
 
+        if search_type == "decisions":
+            # Search decisions table cross-project using LIKE pattern matching.
+            # JOIN with sessions to surface project_name/project_path.
+            pattern = f"%{query}%"
+            cursor = await conn.execute(
+                """
+                SELECT
+                    d.id as session_id,
+                    d.category as title,
+                    d.description as snippet,
+                    NULL as relevance,
+                    s.project_name,
+                    s.project_path,
+                    d.timestamp as started_at,
+                    '[]' as tags
+                FROM decisions d
+                JOIN sessions s ON d.session_id = s.id
+                WHERE d.description LIKE ? OR d.rationale LIKE ? OR d.category LIKE ?
+                ORDER BY d.timestamp DESC
+                LIMIT ?
+                """,
+                (pattern, pattern, pattern, limit),
+            )
+            rows = await cursor.fetchall()
+            return [dict(row) for row in rows]
+
         if search_type == "learnings":
             # Search project_learnings table using LIKE pattern matching
             pattern = f"%{query}%"

--- a/tests/test_search_decisions_cross_project.py
+++ b/tests/test_search_decisions_cross_project.py
@@ -1,0 +1,106 @@
+"""Cross-project decision search via session_search(search_type='decisions').
+
+Verifies that the new 'decisions' branch in `search_sessions` returns matches
+across project_name boundaries — the missing capability called out when
+quarantining the PR #17 corruption.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from src.core.session_engine import SessionIntelligenceEngine
+from src.persistence.sqlite import SQLiteBackend
+
+
+@pytest.fixture
+async def engine_with_decisions(tmp_path):
+    """Engine backed by a fresh SQLite DB with two projects, two decisions each."""
+    db_path = tmp_path / "search_decisions.db"
+    backend = SQLiteBackend(db_path=str(db_path))
+    await backend.initialize()
+
+    engine = SessionIntelligenceEngine(repository_path=str(tmp_path))
+    engine.database = backend
+
+    now = datetime.now(UTC)
+
+    # Two sessions, two distinct project_names
+    sessions = [
+        ("sess-alpha", "alpha-proj", str(tmp_path / "alpha")),
+        ("sess-beta", "beta-proj", str(tmp_path / "beta")),
+    ]
+    for sid, pname, ppath in sessions:
+        await backend.save_session(
+            {
+                "id": sid,
+                "started_at": now,
+                "project_path": ppath,
+                "project_name": pname,
+                "mode": "local",
+                "status": "active",
+                "metadata": {},
+                "performance_metrics": {},
+                "health_status": {},
+            }
+        )
+
+    # Decisions split across both projects, all containing the keyword
+    # "quarantine" so a single query should surface every one of them.
+    decisions = [
+        ("sess-alpha", "Designed quarantine label schema", "architecture"),
+        ("sess-alpha", "Picked Postgres over Mongo", "infra"),
+        ("sess-beta", "Wrote quarantine migration script", "ops"),
+        ("sess-beta", "Skipped quarantine for empty rows", "ops"),
+    ]
+    for sid, desc, cat in decisions:
+        await backend.save_decision(
+            {
+                "id": f"dec-{uuid.uuid4().hex[:8]}",
+                "session_id": sid,
+                "timestamp": now,
+                "category": cat,
+                "description": desc,
+                "rationale": None,
+                "context": {},
+                "impact_level": "medium",
+                "artifacts": [],
+            }
+        )
+
+    yield engine
+    await backend.close()
+
+
+async def test_decisions_search_returns_matches_across_projects(engine_with_decisions):
+    """A keyword query must surface decisions from both projects."""
+    results = await engine_with_decisions.session_search(
+        query="quarantine", search_type="decisions", limit=10
+    )
+
+    assert results.total_results >= 3
+    project_names = {r.project_name for r in results.results}
+    assert project_names == {"alpha-proj", "beta-proj"}
+
+
+async def test_decisions_search_ignores_non_matching_decisions(engine_with_decisions):
+    """Decisions not matching the keyword must be excluded."""
+    results = await engine_with_decisions.session_search(
+        query="quarantine", search_type="decisions", limit=10
+    )
+
+    snippets = " ".join((r.snippet or "") for r in results.results)
+    assert "Postgres over Mongo" not in snippets
+
+
+async def test_decisions_search_empty_when_no_match(engine_with_decisions):
+    """Query with no hits returns zero results, not an error."""
+    results = await engine_with_decisions.session_search(
+        query="nonexistent-keyword-xyz", search_type="decisions", limit=10
+    )
+
+    assert results.total_results == 0
+    assert results.results == []


### PR DESCRIPTION
## Summary

- Adds `search_type='decisions'` branch to `search_sessions` mirroring the existing `'learnings'` branch — closes the gap left after quarantining the PR #17 corruption set under `_archive_pre_fix_`.
- PostgreSQL: full-text search over `decisions(category, description, rationale)` joined with `sessions` to surface `project_name` / `project_path`.
- SQLite: matching `LIKE`-based branch over the same columns.
- `lean_mcp_interface.py`: extends `session_search` enum to include `'decisions'` and `'learnings'`, documents cross-project semantics.
- Defensive fix on `session_engine.py:2219` (`float(result.get('relevance') or 0.0)`) to handle SQL `NULL` relevance returned by SQLite branches — a preexisting latent crash exposed by the new tests.

## Context

In the same maintenance pass we quarantined 243 corrupted sessions (`'.claude'` + `'project-session-'` → `'_archive_pre_fix_'`) and promoted 2,531 linked learnings to `promoted_to_universal=TRUE`. With learnings already cross-project searchable (#16), decisions were the missing piece — they remained tied to a single `project_name`. This PR closes that gap with no new tool, just an enum extension.

## Test plan

- [x] 3 new tests in `tests/test_search_decisions_cross_project.py`:
  - returns matches across two project_names for the same keyword
  - excludes non-matching decisions
  - returns empty results for no-hit query
- [x] Full suite: **334 passed, 62 skipped (Postgres tests skipped without server), 0 failed**
- [x] Lint / format / typecheck: all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)