### PR TITLE
feat: validate agent_name against ~/.claude/agents/ for agent_* write tools

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -126,6 +126,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.16.1-pyhc167863_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.16.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.16.1-h810d63d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
@@ -299,6 +300,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.16.1-pyhc167863_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.16.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.16.1-h810d63d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
@@ -649,6 +651,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.16.1-pyhc167863_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.16.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.16.1-h810d63d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
@@ -830,6 +833,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.16.1-pyhc167863_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.16.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.16.1-h810d63d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
@@ -2791,7 +2795,7 @@ packages:
 - pypi: ./
   name: session-intelligence
   version: 1.0.0
-  sha256: 22d3379124cec5e549fe09d186ec762d977718900204dc81112876d1209f4cb4
+  sha256: 9040be48893f617d54968d9aa57a1bfcfefc2579550490a9134fb3e197008238
   requires_dist:
   - pytest>=7.0.0 ; extra == 'dev'
   - pytest-asyncio>=0.21.0 ; extra == 'dev'
@@ -2980,6 +2984,16 @@ packages:
   purls: []
   size: 5291
   timestamp: 1755547637982
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
+  sha256: 38d66db1dd8a1149b1c444371a2ffc647adaeb9ed3c65874d13e067dbf0368c5
+  md5: 7a260267fdb5d0989fd55f8d822a2927
+  depends:
+  - python >=3.10
+  license: Apache-2.0 AND MIT
+  purls:
+  - pkg:pypi/types-pyyaml?source=hash-mapping
+  size: 22644
+  timestamp: 1775652241720
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
   sha256: 349951278fa8d0860ec6b61fcdc1e6f604e6fce74fabf73af2e39a37979d0223
   md5: 75be1a943e0a7f99fcf118309092c635

--- a/pixi.lock
+++ b/pixi.lock
@@ -197,6 +197,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py313hfab6e84_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.4-py313h3dea7bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.6-py313hafb0bba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-3.22.4-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
@@ -220,6 +222,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
@@ -245,6 +248,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.19.1-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/openapi-core-0.19.5-pyh29332c3_0.conda
@@ -255,6 +259,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parse-1.20.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathable-0.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
@@ -263,8 +270,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyperclip-1.9.0-pyha804496_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-asyncio-0.26.0-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.5-hec9711d_102_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.7.8-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.20-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
@@ -277,6 +288,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.17.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.27.0-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.0-h40fa522_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
@@ -313,12 +325,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py313h536fd9c_2.conda
       - pypi: https://files.pythonhosted.org/packages/ef/39/b2181148075272edfbbd6d87e6cd78cc71dca243446fa3b381fd4116950b/aiosqlite-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/0f/571b2c7a3833ae419fe69ff7b479a78d313581785203cc70a8db90121b9a/numpy-2.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/52/0634adaace9be2d8cac9ef78f05c47f3a675882e068438b9d7ec7ef0c13f/pandas-2.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/eb/4af4bcd5b8731366b676192675221c5324394a580dfae469d498313b5c4a/pathlib2-2.3.7.post1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/72/c86a4cd867816350fe8dee13f30222340b9cd6b96173955819a5561810c5/scikit_learn-1.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -2774,7 +2791,7 @@ packages:
 - pypi: ./
   name: session-intelligence
   version: 1.0.0
-  sha256: 74047f402c9aae97a3bc79a07a1ba38ad627838f234862567e57d9ba58bef8fa
+  sha256: 0e615add8f4e489bf8c19b71f6b215f016003255c1ca79c47ae55786ee48b751
   requires_dist:
   - pytest>=7.0.0 ; extra == 'dev'
   - pytest-asyncio>=0.21.0 ; extra == 'dev'

--- a/pixi.lock
+++ b/pixi.lock
@@ -2791,7 +2791,7 @@ packages:
 - pypi: ./
   name: session-intelligence
   version: 1.0.0
-  sha256: 0e615add8f4e489bf8c19b71f6b215f016003255c1ca79c47ae55786ee48b751
+  sha256: 22d3379124cec5e549fe09d186ec762d977718900204dc81112876d1209f4cb4
   requires_dist:
   - pytest>=7.0.0 ; extra == 'dev'
   - pytest-asyncio>=0.21.0 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ fastapi = ">=0.109.0"
 uvicorn = ">=0.27.0"
 # PostgreSQL support (optional, for production)
 asyncpg = ">=0.29.0"
+pyyaml = ">=6.0"
 
 [tool.pixi.pypi-dependencies]
 session-intelligence = { path = ".", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,6 @@ daemon-status = { cmd = "scripts/session-intelligence-daemon.sh status" }
 migrate-from-sqlite = { cmd = "python -m persistence.migration sqlite-to-postgres", env = { PYTHONPATH = "src" } }
 db-export = { cmd = "python -m persistence.migration export", env = { PYTHONPATH = "src" } }
 # Quality tasks
-test = "pytest tests/ -v --ignore=tests/live --ignore=tests/debug"
-test-unit = "pytest tests/unit -v"
-test-integration = "pytest tests/integration -v"
-test-debug = "pytest tests/debug -v"
-test-live = "pytest tests/live -v"
-test-all = "pytest tests/ -v"
-test-cov = "pytest tests/ -v --cov=src --cov-report=term-missing --cov-report=html"
 lint = "ruff check src/ --fix"
 format = "black src/ tests/"
 type-check = "mypy src/"
@@ -89,6 +82,15 @@ quality = { depends-on = ["lint", "type-check-lenient"] }
 type-check-lenient = "mypy src/ || echo 'mypy: warnings found (non-blocking)'"
 check-all = { depends-on = ["test", "quality"] }
 build = "python -m build"
+
+[tool.pixi.feature.quality.tasks]
+test = "pytest tests/ -v --ignore=tests/live --ignore=tests/debug"
+test-unit = "pytest tests/unit -v"
+test-integration = "pytest tests/integration -v"
+test-debug = "pytest tests/debug -v"
+test-live = "pytest tests/live -v"
+test-all = "pytest tests/ -v"
+test-cov = "pytest tests/ -v --cov=src --cov-report=term-missing --cov-report=html"
 
 [tool.pixi.feature.quality.dependencies]
 pytest = ">=7.0.0"
@@ -107,7 +109,7 @@ pytest-timeout = ">=2.1.0"
 bandit = ">=1.7.0"
 
 [tool.pixi.environments]
-default = { solve-group = "default" }
+default = { features = ["quality"], solve-group = "default" }
 dev = { features = ["dev"], solve-group = "default" }
 ci = { features = ["quality"], solve-group = "default" }
 quality-ci = { features = ["quality"], solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ pytest-asyncio = ">=0.21.0,<1.0.0"
 pytest-cov = ">=4.0.0"
 ruff = ">=0.1.0"
 mypy = ">=1.5.0"
+types-pyyaml = ">=6.0"
 
 [tool.pixi.feature.quality.pypi-dependencies]
 black = ">=23.0.0"

--- a/src/core/agent_validator.py
+++ b/src/core/agent_validator.py
@@ -1,0 +1,159 @@
+"""Validate agent names against real agent files under ~/.claude/agents and extract metadata."""
+
+import difflib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_AGENTS_ROOT_ENV = "SESSION_INTELLIGENCE_AGENTS_DIR"
+_MODE_ENV = "SESSION_INTELLIGENCE_AGENT_VALIDATION"
+_VALID_MODES = {"strict", "lenient", "off"}
+_DEFAULT_AGENTS_ROOT = Path("~/.claude/agents").expanduser()
+_DESCRIPTION_MAX_LEN = 500
+
+
+class AgentNotFoundError(ValueError):
+    """Raised when an agent name has no matching file and mode is strict."""
+
+
+class AmbiguousAgentNameError(ValueError):
+    """Raised when an agent name matches multiple files under different subdirs."""
+
+
+@dataclass(frozen=True)
+class ValidatedAgent:
+    name: str
+    agent_type: str
+    description: str
+    file_path: Path
+    raw_frontmatter: dict[str, Any]
+
+
+def _parse_frontmatter(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    if not text.startswith("---"):
+        return {}
+
+    end = text.find("---", 3)
+    if end == -1:
+        return {}
+
+    try:
+        data = yaml.safe_load(text[3:end])
+        return data if isinstance(data, dict) else {}
+    except yaml.YAMLError:
+        return {}
+
+
+def _normalize_description(raw: str) -> str:
+    stripped = raw.strip()
+    collapsed = re.sub(r"\s+", " ", stripped)
+    if len(collapsed) > _DESCRIPTION_MAX_LEN:
+        return collapsed[:_DESCRIPTION_MAX_LEN] + "…"
+    return collapsed
+
+
+class AgentValidator:
+    def __init__(
+        self,
+        agents_root: Path | None = None,
+        mode: str | None = None,
+    ) -> None:
+        self._agents_root = self._resolve_root(agents_root)
+        self._mode = self._resolve_mode(mode)
+        self._cache: dict[str, list[Path]] = {}
+
+        if self._mode != "off":
+            if self._agents_root is None or not self._agents_root.exists():
+                logger.warning(
+                    "agents_root %r does not exist — agent validation disabled",
+                    self._agents_root,
+                )
+                self._mode = "off"
+            else:
+                self._cache = self._build_cache()
+
+    @staticmethod
+    def _resolve_root(agents_root: Path | None) -> Path:
+        if agents_root is not None:
+            return agents_root
+        env_val = os.environ.get(_AGENTS_ROOT_ENV)
+        if env_val:
+            return Path(env_val)
+        return _DEFAULT_AGENTS_ROOT
+
+    @staticmethod
+    def _resolve_mode(mode: str | None) -> str:
+        if mode is not None:
+            if mode not in _VALID_MODES:
+                raise ValueError(f"mode must be one of {_VALID_MODES}, got {mode!r}")
+            return mode
+        env_val = os.environ.get(_MODE_ENV, "").lower()
+        if env_val in _VALID_MODES:
+            return env_val
+        return "strict"
+
+    def _build_cache(self) -> dict[str, list[Path]]:
+        cache: dict[str, list[Path]] = {}
+        for md_file in self._agents_root.glob("**/*.md"):
+            name = md_file.stem
+            cache.setdefault(name, []).append(md_file)
+        return cache
+
+    def validate(self, agent_name: str) -> ValidatedAgent | None:
+        if self._mode == "off":
+            return None
+
+        matches = self._cache.get(agent_name, [])
+
+        if len(matches) > 1:
+            paths_str = ", ".join(str(p) for p in matches)
+            raise AmbiguousAgentNameError(
+                f"Multiple agent files named {agent_name!r}: {paths_str}"
+            )
+
+        if len(matches) == 1:
+            path = matches[0]
+            frontmatter = _parse_frontmatter(path)
+            raw_desc = frontmatter.get("description", "") or ""
+            description = _normalize_description(str(raw_desc))
+            agent_type = path.parent.name
+            return ValidatedAgent(
+                name=agent_name,
+                agent_type=agent_type,
+                description=description,
+                file_path=path,
+                raw_frontmatter=frontmatter,
+            )
+
+        # No match
+        closest = self.find_closest(agent_name)
+        if self._mode == "strict":
+            raise AgentNotFoundError(
+                f"Agent {agent_name!r} not found in {self._agents_root}. "
+                f"Closest matches: {closest}"
+            )
+        logger.warning(
+            "Agent %r not found in %s (closest: %s)",
+            agent_name,
+            self._agents_root,
+            closest,
+        )
+        return None
+
+    def find_closest(self, agent_name: str, n: int = 5) -> list[str]:
+        return difflib.get_close_matches(agent_name, self.list_known_agents(), n=n, cutoff=0.5)
+
+    def list_known_agents(self) -> list[str]:
+        return list(self._cache.keys())

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from core.agent_validator import AgentValidator
 from models.session_models import (
     Agent,
     AgentDecision,
@@ -167,6 +168,8 @@ class SessionIntelligenceEngine:
             debug_logger.info(
                 "Filesystem persistence disabled - using memory only"
             )
+
+        self._agent_validator = AgentValidator()  # env-driven config, defaults to strict
 
     def _get_or_create_current_session_id(self) -> str | None:
         """Get current session ID from cache/file, or create new session if needed."""
@@ -2601,6 +2604,21 @@ class SessionIntelligenceEngine:
             AgentRegistrationResult with status 'created', 'updated', or
                 'error'
         """
+        # Raises AgentNotFoundError in strict mode; None in lenient/off
+        validated = self._agent_validator.validate(agent_name)
+        if validated is not None:
+            # Frontmatter is canonical; caller args are advisory hints
+            if agent_type and agent_type != validated.agent_type:
+                debug_logger.warning(
+                    f"agent_register: caller passed agent_type={agent_type!r} but "
+                    f"{agent_name!r} lives in {validated.agent_type!r} dir; using filesystem value"
+                )
+            agent_type = validated.agent_type
+            if not description:
+                description = validated.description
+            if not display_name:
+                display_name = validated.raw_frontmatter.get("display_name") or agent_name
+
         if not self.database:
             debug_logger.warning("agent_register called without database")
             return AgentRegistrationResult(
@@ -2816,6 +2834,8 @@ class SessionIntelligenceEngine:
         Returns:
             AgentDecisionResult with decision_id and status
         """
+        self._agent_validator.validate(agent_name)  # raises AgentNotFoundError in strict mode
+
         if not self.database:
             debug_logger.warning(
                 "agent_log_decision called without database"
@@ -3083,6 +3103,8 @@ class SessionIntelligenceEngine:
         Returns:
             AgentLearningResult with learning_id and status
         """
+        self._agent_validator.validate(agent_name)  # raises AgentNotFoundError in strict mode
+
         if not self.database:
             debug_logger.warning(
                 "agent_log_learning called without database"
@@ -3379,6 +3401,8 @@ class SessionIntelligenceEngine:
         Returns:
             AgentNotebookResult with notebook_id and status
         """
+        self._agent_validator.validate(agent_name)  # raises AgentNotFoundError in strict mode
+
         if not self.database:
             debug_logger.warning(
                 "agent_create_notebook called without database"

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -101,7 +101,7 @@ class NotificationManager:
                         queue.get(), timeout=idle_timeout
                     )
                     yield notification
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     break
         finally:
             self._subscribers.pop(mcp_session_id, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,8 @@ This module provides common fixtures used across all test categories:
 import os
 import sys
 import tempfile
+from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
-from typing import AsyncGenerator, Generator
 
 import pytest
 
@@ -80,9 +80,13 @@ async def sqlite_backend(sqlite_db_path: Path) -> AsyncGenerator:
 # ============================================================================
 
 @pytest.fixture
-def session_engine(temp_dir: Path):
+def session_engine(temp_dir: Path, monkeypatch):
     """Create a session engine for testing."""
     from core.session_engine import SessionIntelligenceEngine
+
+    # Disable agent-name validation so tests using synthetic names like
+    # "test-agent" do not require matching files under ~/.claude/agents/.
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
 
     engine = SessionIntelligenceEngine(repository_path=str(temp_dir))
     return engine

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -12,13 +12,18 @@ from persistence.sqlite import SQLiteBackend
 
 
 @pytest.fixture
-async def engine(tmp_path):
+async def engine(tmp_path, monkeypatch):
     """
     Yield a fully-initialised SessionIntelligenceEngine backed by SQLite.
 
     A fresh database file is created under pytest's tmp_path for each test,
     so tests are fully isolated from one another.
+
+    Agent-name validation is disabled so tests using synthetic names like
+    "test-agent" do not require matching files under ~/.claude/agents/.
     """
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+
     db_path = str(tmp_path / "test_engine.db")
     db = SQLiteBackend(db_path)
     await db.initialize()

--- a/tests/unit/test_agent_validator.py
+++ b/tests/unit/test_agent_validator.py
@@ -1,0 +1,269 @@
+"""Unit tests for core/agent_validator.py.
+
+All tests use tmp_path to create isolated fake agent directories and are
+completely isolated from the real ~/.claude/agents/ directory tree.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from core.agent_validator import (
+    AgentNotFoundError,
+    AgentValidator,
+    AmbiguousAgentNameError,
+    ValidatedAgent,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_agent(base: Path, subdir: str, stem: str, frontmatter: str = "") -> Path:
+    """Write a fake agent .md file and return its path."""
+    target_dir = base / subdir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    if frontmatter:
+        content = f"---\n{frontmatter}\n---\n# Agent\nBody text.\n"
+    else:
+        content = "# Agent\nBody text.\n"
+    path = target_dir / f"{stem}.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic resolution
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorFindsAgentInSubdir:
+    def test_finds_domain_agent(self, tmp_path: Path) -> None:
+        _write_agent(
+            tmp_path,
+            "domain",
+            "foo-agent",
+            "name: foo-agent\ndescription: Foo bar\nmodel: sonnet",
+        )
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+        result = validator.validate("foo-agent")
+
+        assert isinstance(result, ValidatedAgent)
+        assert result.name == "foo-agent"
+        assert result.agent_type == "domain"
+        assert result.description == "Foo bar"
+
+
+# ---------------------------------------------------------------------------
+# 2. Strict mode — unknown agent
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorStrictRaisesOnUnknown:
+    def test_raises_agent_not_found(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "domain", "real-agent", "name: real-agent\ndescription: Real")
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+
+        with pytest.raises(AgentNotFoundError) as exc_info:
+            validator.validate("nonexistent")
+
+        msg = str(exc_info.value)
+        assert "Closest matches" in msg
+        # At least one known agent name should appear
+        assert "real-agent" in msg or len(validator.list_known_agents()) > 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Lenient mode — unknown agent
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorLenientReturnsNone:
+    def test_returns_none_and_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_agent(tmp_path, "domain", "some-agent", "name: some-agent")
+        validator = AgentValidator(agents_root=tmp_path, mode="lenient")
+
+        with caplog.at_level(logging.WARNING, logger="core.agent_validator"):
+            result = validator.validate("nonexistent-agent")
+
+        assert result is None
+        assert any("not found" in record.message.lower() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 4. Off mode
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorOffReturnsNoneAlways:
+    def test_returns_none_for_known_agent(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "domain", "known-agent", "name: known-agent")
+        validator = AgentValidator(agents_root=tmp_path, mode="off")
+        assert validator.validate("known-agent") is None
+
+    def test_returns_none_for_unknown_agent(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "domain", "known-agent", "name: known-agent")
+        validator = AgentValidator(agents_root=tmp_path, mode="off")
+        assert validator.validate("totally-unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Ambiguous name
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorAmbiguousNameRaises:
+    def test_raises_ambiguous_error(self, tmp_path: Path) -> None:
+        _write_agent(tmp_path, "domain", "dup", "name: dup")
+        _write_agent(tmp_path, "meta", "dup", "name: dup")
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+
+        with pytest.raises(AmbiguousAgentNameError) as exc_info:
+            validator.validate("dup")
+
+        msg = str(exc_info.value)
+        # Both paths should appear in the error
+        assert "domain" in msg
+        assert "meta" in msg
+
+
+# ---------------------------------------------------------------------------
+# 6. Missing root — auto-degrades to off
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorHandlesMissingRoot:
+    def test_degrades_to_off_when_root_missing(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "does_not_exist"
+        validator = AgentValidator(agents_root=nonexistent, mode="strict")
+        # After degradation, validate returns None instead of raising
+        result = validator.validate("any-agent")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 7. No frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorHandlesNoFrontmatter:
+    def test_empty_frontmatter(self, tmp_path: Path) -> None:
+        target = tmp_path / "domain"
+        target.mkdir()
+        (target / "bare-agent.md").write_text("# Agent\nNo frontmatter here.\n", encoding="utf-8")
+
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+        result = validator.validate("bare-agent")
+
+        assert isinstance(result, ValidatedAgent)
+        assert result.raw_frontmatter == {}
+        assert result.description == ""
+
+
+# ---------------------------------------------------------------------------
+# 8. Malformed YAML
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorHandlesMalformedYaml:
+    def test_malformed_yaml_gives_empty_frontmatter(self, tmp_path: Path) -> None:
+        target = tmp_path / "domain"
+        target.mkdir()
+        (target / "broken-agent.md").write_text(
+            "---\nname: [unclosed\n---\n# Body\n", encoding="utf-8"
+        )
+
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+        result = validator.validate("broken-agent")
+
+        assert isinstance(result, ValidatedAgent)
+        assert result.raw_frontmatter == {}
+        assert result.description == ""
+
+
+# ---------------------------------------------------------------------------
+# 9. Long description truncation
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorTruncatesLongDescription:
+    def test_description_truncated_at_500(self, tmp_path: Path) -> None:
+        long_desc = "x" * 600
+        frontmatter = f"name: verbose-agent\ndescription: {long_desc}"
+        _write_agent(tmp_path, "domain", "verbose-agent", frontmatter)
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+        result = validator.validate("verbose-agent")
+
+        assert isinstance(result, ValidatedAgent)
+        assert len(result.description) <= 503  # 500 chars + up to 3-char ellipsis
+        assert result.description.endswith("…") or result.description.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# 10. Multi-line description collapsed
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorCollapsesMultilineDescription:
+    def test_block_scalar_description_collapsed(self, tmp_path: Path) -> None:
+        frontmatter = (
+            "name: multi-agent\ndescription: |\n"
+            "  First line.\n  Second line.\n  Third line.\n"
+        )
+        _write_agent(tmp_path, "domain", "multi-agent", frontmatter)
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+        result = validator.validate("multi-agent")
+
+        assert isinstance(result, ValidatedAgent)
+        assert "\n" not in result.description
+        # Consecutive whitespace should be collapsed
+        assert "  " not in result.description
+
+
+# ---------------------------------------------------------------------------
+# 11. find_closest top-N
+# ---------------------------------------------------------------------------
+
+
+class TestFindClosestReturnsTopN:
+    def test_returns_at_most_n_matches(self, tmp_path: Path) -> None:
+        for i in range(5):
+            _write_agent(tmp_path, "domain", f"foobar-agent-{i}", f"name: foobar-agent-{i}")
+        validator = AgentValidator(agents_root=tmp_path, mode="strict")
+        closest = validator.find_closest("foobar", n=3)
+        assert len(closest) <= 3
+
+
+# ---------------------------------------------------------------------------
+# 12. Env var controls mode
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarControlsMode:
+    def test_env_off_prevents_raise(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_agent(tmp_path, "domain", "real-agent", "name: real-agent")
+        monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+        monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", str(tmp_path))
+        # Instantiate with no explicit args — should pick up env vars
+        validator = AgentValidator()
+        result = validator.validate("nonexistent-agent")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 13. Env var controls agents dir
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarControlsAgentsDir:
+    def test_env_dir_picked_up(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_agent(tmp_path, "domain", "env-agent", "name: env-agent")
+        monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", str(tmp_path))
+        monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "strict")
+        validator = AgentValidator()
+        known = validator.list_known_agents()
+        assert "env-agent" in known

--- a/tests/unit/test_session_engine_agent_validation.py
+++ b/tests/unit/test_session_engine_agent_validation.py
@@ -1,0 +1,321 @@
+"""Tests for AgentValidator wiring inside SessionIntelligenceEngine.
+
+Uses an in-memory SQLite backend and a tmp_path agents directory so tests
+are fully isolated from real filesystem state and PostgreSQL.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from core.agent_validator import AgentNotFoundError
+from core.session_engine import SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_agent(base: Path, subdir: str, stem: str, frontmatter: str = "") -> Path:
+    """Write a minimal agent .md file under base/subdir/stem.md."""
+    target_dir = base / subdir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    content = (
+        f"---\n{frontmatter}\n---\n# Agent\nBody.\n"
+        if frontmatter
+        else "# Agent\nBody.\n"
+    )
+    path = target_dir / f"{stem}.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory SQLite database, initialized and cleaned up per test."""
+    backend = SQLiteBackend(db_path=":memory:")
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+def agents_dir(tmp_path: Path) -> Path:
+    """Isolated agents root directory."""
+    return tmp_path / "agents"
+
+
+@pytest.fixture
+def engine(db, agents_dir, monkeypatch: pytest.MonkeyPatch) -> SessionIntelligenceEngine:
+    """Engine wired to in-memory SQLite and isolated agents_dir in strict mode."""
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", str(agents_dir))
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "strict")
+    eng = SessionIntelligenceEngine(
+        repository_path=None,
+        use_filesystem=False,
+        database=db,
+    )
+    return eng
+
+
+# ---------------------------------------------------------------------------
+# 1. agent_register overrides agent_type from filesystem
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRegisterValidatesAndOverridesType:
+    async def test_type_from_frontmatter_wins(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _write_agent(
+            agents_dir,
+            "meta",
+            "test-agent",
+            "name: test-agent\ndescription: Test agent for wiring tests",
+        )
+        # Reinitialise validator so it picks up the newly written file
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        with caplog.at_level(logging.WARNING):
+            result = await engine.agent_register(
+                agent_name="test-agent",
+                agent_type="domain",  # Wrong — file lives under meta/
+                description="caller desc",
+                display_name=None,
+                metadata={},
+                capabilities=[],
+            )
+
+        assert result.status in ("created", "updated")
+        # Verify persisted record has filesystem type
+        agent_data = await engine.database.get_agent_by_name("test-agent")
+        assert agent_data is not None
+        assert agent_data["agent_type"] == "meta"
+        # Warning about type override should have been logged
+        assert any("meta" in r.message or "domain" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 2. Frontmatter description used when caller omits it
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRegisterUsesFrontmatterDescription:
+    async def test_frontmatter_description_as_fallback(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        _write_agent(
+            agents_dir,
+            "domain",
+            "desc-agent",
+            "name: desc-agent\ndescription: Frontmatter description",
+        )
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        result = await engine.agent_register(
+            agent_name="desc-agent",
+            agent_type="domain",
+            description=None,
+            display_name=None,
+            metadata={},
+            capabilities=[],
+        )
+
+        assert result.status in ("created", "updated")
+        agent_data = await engine.database.get_agent_by_name("desc-agent")
+        assert agent_data is not None
+        assert agent_data["description"] == "Frontmatter description"
+
+
+# ---------------------------------------------------------------------------
+# 3. Caller description wins over frontmatter when provided
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRegisterKeepsCallerDescription:
+    async def test_caller_description_takes_precedence(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        _write_agent(
+            agents_dir,
+            "domain",
+            "prio-agent",
+            "name: prio-agent\ndescription: Frontmatter description",
+        )
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        result = await engine.agent_register(
+            agent_name="prio-agent",
+            agent_type="domain",
+            description="caller's text",
+            display_name=None,
+            metadata={},
+            capabilities=[],
+        )
+
+        assert result.status in ("created", "updated")
+        agent_data = await engine.database.get_agent_by_name("prio-agent")
+        assert agent_data is not None
+        assert agent_data["description"] == "caller's text"
+
+
+# ---------------------------------------------------------------------------
+# 4. agent_register raises on unknown agent in strict mode
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRegisterRaisesOnUnknown:
+    async def test_raises_agent_not_found(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        with pytest.raises(AgentNotFoundError):
+            await engine.agent_register(
+                agent_name="ghost-agent",
+                agent_type="domain",
+                description=None,
+                display_name=None,
+                metadata={},
+                capabilities=[],
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. agent_log_decision raises on unknown agent
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLogDecisionRaisesOnUnknown:
+    async def test_raises_agent_not_found(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        with pytest.raises(AgentNotFoundError):
+            await engine.agent_log_decision(
+                agent_name="ghost-agent",
+                decision_type="implementation",
+                context="some context",
+                decision="some decision",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 6. agent_log_learning raises on unknown agent
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLogLearningRaisesOnUnknown:
+    async def test_raises_agent_not_found(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        with pytest.raises(AgentNotFoundError):
+            await engine.agent_log_learning(
+                agent_name="ghost-agent",
+                learning_type="pattern",
+                title="some learning",
+                content="some content",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 7. agent_create_notebook raises on unknown agent
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCreateNotebookRaisesOnUnknown:
+    async def test_raises_agent_not_found(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        with pytest.raises(AgentNotFoundError):
+            await engine.agent_create_notebook(
+                agent_name="ghost-agent",
+                title="My Notebook",
+                content="Notebook content.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 8. agent_get_info does NOT validate (read-only path)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentGetInfoDoesNotValidate:
+    async def test_returns_none_without_raising(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        # Should not raise even though "ghost-agent" doesn't exist anywhere
+        result = await engine.agent_get_info("ghost-agent")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 9. agent_query_decisions does NOT validate (read-only path)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentQueryDecisionsDoesNotValidate:
+    async def test_returns_empty_without_raising(
+        self,
+        engine: SessionIntelligenceEngine,
+        agents_dir: Path,
+    ) -> None:
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        from core.agent_validator import AgentValidator
+
+        engine._agent_validator = AgentValidator(agents_root=agents_dir, mode="strict")
+
+        result = await engine.agent_query_decisions(agent_name="ghost-agent")
+        assert result == []


### PR DESCRIPTION
## Summary

Adds filesystem-backed validation for `agent_name` in every `agent_*` MCP write tool. The framework now refuses to register / log decisions / log learnings / create notebooks for agent names that don't correspond to an actual agent file under `~/.claude/agents/{type}/{name}.md`.

**Why**: Agent transcripts (e.g. the OCaml win-arm64 debug session) showed agents creating duplicate decisions/learnings under typo'd names and tagging notebooks under wrong projects. Filesystem-as-source-of-truth is the simplest enforcement: if the agent file doesn't exist on disk, the registry can't be polluted with it.

## Commits

- `ee104560` `fix(pixi): bind test tasks to quality feature env` — moves test tasks to `[tool.pixi.feature.quality.tasks]` and adds `quality` to `default` env so `pixi run test-unit` works without `-e ci`.
- `1d428cef` `feat: add agent_validator module with AgentValidator and pyyaml dependency` — new `src/core/agent_validator.py` (~160 lines): `AgentValidator` (strict/lenient/off modes), `ValidatedAgent` dataclass, `AgentNotFoundError` (closest-match suggestions via `difflib`), `AmbiguousAgentNameError`, YAML frontmatter parser that handles missing/malformed gracefully, env-driven config (`SESSION_INTELLIGENCE_AGENTS_DIR`, `SESSION_INTELLIGENCE_AGENT_VALIDATION`), auto-degrade to off when agents_root is missing (CI safety). Adds `pyyaml >= 6.0` to default deps.
- `f5af3d32` `feat(engine): wire AgentValidator into agent write methods` — instantiates validator in `__init__`; validates in `agent_register` (also overrides `agent_type` from filesystem and falls back to frontmatter for description/display_name when caller omits), `agent_log_decision`, `agent_log_learning`, `agent_create_notebook`. Read-only methods (`agent_get_info`, `agent_query_*`, `agent_update_*_outcome`, `agent_search_all`) deliberately skip validation — their public contract of returning None/empty for unknown names is preserved. Test fixtures monkeypatch the env var to 'off' so legacy synthetic-name tests still pass. Adds `types-pyyaml` to quality deps. 14 unit tests + 9 wiring tests, all green.
- `e99209bb` `chore(http_server): use built-in TimeoutError` — replace deprecated `asyncio.TimeoutError`, picked up by lint hook.

## Test Plan

- [ ] CI runs `pixi run test-unit` and reports green
- [ ] CI lint passes on changed files
- [ ] CI mypy passes (`types-pyyaml` resolves the import-untyped warning)
- [ ] Spot-check: registering an agent with a name not on disk raises `AgentNotFoundError` with closest-match suggestions
- [ ] Spot-check: registering an agent with `agent_type='wrong'` overrides to actual filesystem dir + logs a warning

## Follow-ups (separate PRs)

- **PR C**: Description rewrites for `agent_*` and `session_*` tools — communicate the 3-tier semantic model (decision/learning/notebook), routing hint at meta-tool layer, canonical "discover-then-update" examples in `get_tool_spec`, rename `notebook_type` enum values.
- **PR B**: Flexible session identifier resolver — `_resolve_session_context(session_id?, session_name?, project_name?)` accepting any of three. Removes silent `_unbound_` fallback. Ship after C educates callers.