### PR TITLE
feat(interface): add system/tier framing to all tool descriptions

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2795,7 +2795,7 @@ packages:
 - pypi: ./
   name: session-intelligence
   version: 1.0.0
-  sha256: 5291d1203d819d133e8390e4aea9d1849b15b24ac362d80e00aeeabbde795ad4
+  sha256: 9040be48893f617d54968d9aa57a1bfcfefc2579550490a9134fb3e197008238
   requires_dist:
   - pytest>=7.0.0 ; extra == 'dev'
   - pytest-asyncio>=0.21.0 ; extra == 'dev'

--- a/pixi.lock
+++ b/pixi.lock
@@ -2795,7 +2795,7 @@ packages:
 - pypi: ./
   name: session-intelligence
   version: 1.0.0
-  sha256: 9040be48893f617d54968d9aa57a1bfcfefc2579550490a9134fb3e197008238
+  sha256: 5291d1203d819d133e8390e4aea9d1849b15b24ac362d80e00aeeabbde795ad4
   requires_dist:
   - pytest>=7.0.0 ; extra == 'dev'
   - pytest-asyncio>=0.21.0 ; extra == 'dev'

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -161,7 +161,16 @@ class LeanMCPInterface:
 
         registry["session_log_decision"] = {
             "implementation": self._wrap_async_tool(self.session_engine.session_log_decision),
-            "description": "Log decisions with context and impact analysis",
+            "description": (
+                "Log a decision made on this project. "
+                "**SYSTEM**: session — project-scoped work history bound to project_name. "
+                "**TIER**: decision — atomic choice (what was decided + reasoning). "
+                "**ANTI-DUPE**: call session_recall(project_name=X) or "
+                "session_search(query=Y) FIRST to find existing decisions covering the "
+                "same ground; extend or supersede rather than re-log. "
+                "**DISCIPLINE**: pass project_name explicitly — never let it fall back "
+                "to _unbound_."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -181,9 +190,9 @@ class LeanMCPInterface:
                     "project_name": {
                         "type": "string",
                         "description": (
-                            "Optional project name to bind decision to. "
-                            "Creates/selects a session with this project_name "
-                            "if needed."
+                            "Project name to bind decision to — pass EXPLICITLY. "
+                            "Creates/selects a session with this project_name if needed. "
+                            "Omitting silently falls back to _unbound_ and corrupts retrieval."
                         ),
                     },
                 },
@@ -191,9 +200,16 @@ class LeanMCPInterface:
             },
             "examples": [
                 {
+                    "_workflow_hint": "STEP 1: query first to dedupe",
+                    "project_name": "my-project",
+                    "decision": "session_recall or session_search goes here first",
+                },
+                {
+                    "_workflow_hint": "STEP 2: log only if no matching decision found above",
                     "decision": "Switch to pytest for testing",
                     "context": {"reason": "Better async support"},
-                }
+                    "project_name": "my-project",
+                },
             ],
         }
 
@@ -428,7 +444,13 @@ class LeanMCPInterface:
                 self.session_engine.session_create_notebook_async
             ),
             "description": (
-                "Generate markdown notebook/summary at session end with searchable content"
+                "Create a reasoning narrative for this project session. "
+                "**SYSTEM**: session — project-scoped work history. "
+                "**TIER**: notebook — reasoning narrative recording abandoned paths, "
+                "hypotheses, and context that lets future readers judge whether stored "
+                "decisions/learnings are still valid. Call at session end or at a "
+                "natural breakpoint. Use session_query_notebooks first if you want to "
+                "avoid duplicate session records."
             ),
             "schema": {
                 "type": "object",
@@ -471,14 +493,29 @@ class LeanMCPInterface:
                 },
             },
             "examples": [
-                {"title": "Feature Implementation Session", "tags": ["feature", "python"]},
-                {"include_metrics": False, "save_to_file": True},
+                {
+                    "_workflow_hint": "STEP 1: check existing notebooks to avoid duplicates",
+                    "project_path": "/path/to/project",
+                },
+                {
+                    "_workflow_hint": "STEP 2: log only if no recent notebook for this session",
+                    "title": "Feature Implementation Session",
+                    "tags": ["feature", "python"],
+                },
             ],
         }
 
         registry["session_search"] = {
             "implementation": self._wrap_async_tool(self.session_engine.session_search),
-            "description": "Full-text search across session notebooks and summaries",
+            "description": (
+                "Full-text search across session notebooks, decisions, and learnings. "
+                "**SYSTEM**: session (with cross-project reach for decisions/learnings). "
+                "**READS**: all three tiers — notebook narratives (fulltext/tag/file), "
+                "project decisions (search_type='decisions', cross-project), "
+                "project learnings (search_type='learnings', cross-project). "
+                "**USE AS STEP 1** in the anti-dupe protocol before logging any "
+                "new session decision or learning. Supports FTS5 syntax: AND, OR, NOT, phrases."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -506,12 +543,20 @@ class LeanMCPInterface:
             "examples": [
                 {"query": "authentication bug fix"},
                 {"query": "python", "search_type": "tag", "limit": 10},
+                {"query": "pytest migration", "search_type": "decisions"},
             ],
         }
 
         registry["session_query_notebooks"] = {
             "implementation": self._wrap_async_tool(self.session_engine.session_query_notebooks),
-            "description": "Query session notebooks/summaries with optional filters",
+            "description": (
+                "Query session notebooks (reasoning narratives) with optional filters. "
+                "**SYSTEM**: session — project-scoped work history. "
+                "**READS**: notebook tier — session narrative records. "
+                "Use as STEP 1 in the anti-dupe protocol before creating a new session "
+                "notebook. Filter by project_path or tags to find existing narratives "
+                "for the current work context."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -540,7 +585,15 @@ class LeanMCPInterface:
 
         registry["session_recall"] = {
             "implementation": self._wrap_async_tool(self.session_engine.session_recall),
-            "description": "Recall project knowledge across all sessions",
+            "description": (
+                "Recall all stored knowledge for a specific project across all sessions. "
+                "**SYSTEM**: session — project-scoped work history. "
+                "**READS**: all three tiers — sessions, decisions, learnings, and notebooks "
+                "for the named project. "
+                "**USE AS STEP 1** in the anti-dupe protocol: call this before logging "
+                "new decisions or learnings to surface what was already recorded. "
+                "Requires project_name (explicit — do not omit)."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -584,7 +637,15 @@ class LeanMCPInterface:
 
         registry["session_log_learning"] = {
             "implementation": self._wrap_async_tool(self.session_engine.session_log_learning),
-            "description": "Log a project-specific learning (pattern, fix, preference, workflow)",
+            "description": (
+                "Log a reusable pattern or fix discovered while working on this project. "
+                "**SYSTEM**: session — project-scoped work history. "
+                "**TIER**: learning — reusable pattern with when/how-to-apply guidance. "
+                "**ANTI-DUPE**: call session_search(query=X, search_type='learnings') "
+                "or session_recall(project_name=Y) FIRST; if a similar pattern exists, "
+                "prefer updating or extending it over creating a duplicate. "
+                "**DISCIPLINE**: pass project_path explicitly to scope the learning."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -610,13 +671,15 @@ class LeanMCPInterface:
             },
             "examples": [
                 {
+                    "_workflow_hint": "STEP 1: search existing learnings before logging",
+                    "query": "ModuleNotFoundError",
+                    "search_type": "learnings",
+                },
+                {
+                    "_workflow_hint": "STEP 2: log only if no matching learning found above",
                     "category": "error_fix",
                     "learning_content": "ImportError for module X: install via pip install X",
                     "trigger_context": "When seeing 'ModuleNotFoundError: X'",
-                },
-                {
-                    "category": "pattern",
-                    "learning_content": "Always run lint before commit in this project",
                 },
             ],
         }
@@ -676,7 +739,14 @@ class LeanMCPInterface:
 
         registry["agent_register"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_register),
-            "description": "Register or update an agent in the global agent registry",
+            "description": (
+                "Register or update an agent in the global cross-project agent registry. "
+                "**SYSTEM**: agent — global pattern library, not bound to any project. "
+                "agent_name MUST match the filename stem of a file under "
+                "~/.claude/agents/{type}/{name}.md (validated; raises AgentNotFoundError "
+                "on typo). Call agent_get_info(agent_name=X) first to check if already "
+                "registered before re-registering."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -712,13 +782,17 @@ class LeanMCPInterface:
             },
             "examples": [
                 {
+                    "_workflow_hint": "STEP 1: check if agent already registered",
+                    "agent_name": "focused-quality-resolver",
+                },
+                {
+                    "_workflow_hint": "STEP 2: register only if agent_get_info returned not-found",
                     "agent_name": "focused-quality-resolver",
                     "agent_type": "focused",
                     "display_name": "Quality Resolver",
                     "description": "Resolves code quality issues",
                     "capabilities": ["lint-fix", "format", "type-check"],
                 },
-                {"agent_name": "micro-test-runner", "agent_type": "micro"},
             ],
         }
 
@@ -743,7 +817,16 @@ class LeanMCPInterface:
 
         registry["agent_log_decision"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_log_decision),
-            "description": "Log a decision made by an agent with context and reasoning",
+            "description": (
+                "Log a decision made by this agent that applies across projects. "
+                "**SYSTEM**: agent — global cross-project pattern library; agent_name "
+                "MUST match ~/.claude/agents/{type}/{name}.md (validated). "
+                "**TIER**: decision — atomic choice (what was decided + reasoning), "
+                "queryable and valid-now. "
+                "**ANTI-DUPE**: call agent_query_decisions(agent_name=X, "
+                "decision_type=Y) FIRST; if a similar decision exists, update its "
+                "outcome via agent_update_decision_outcome instead of re-logging."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -786,6 +869,12 @@ class LeanMCPInterface:
             },
             "examples": [
                 {
+                    "_workflow_hint": "STEP 1: query existing decisions before logging",
+                    "agent_name": "focused-quality-resolver",
+                    "decision_type": "tool_selection",
+                },
+                {
+                    "_workflow_hint": "STEP 2: log only if no matching decision found above",
                     "agent_name": "focused-quality-resolver",
                     "decision_type": "tool_selection",
                     "context": "Multiple lint errors in Python file",
@@ -794,13 +883,20 @@ class LeanMCPInterface:
                     "alternatives": ["Manual fixes", "Black + isort separately"],
                     "confidence": 0.9,
                     "tags": ["python", "linting"],
-                }
+                },
             ],
         }
 
         registry["agent_query_decisions"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_query_decisions),
-            "description": "Query decisions made by an agent with optional filters",
+            "description": (
+                "Query decisions logged for an agent across all projects. "
+                "**SYSTEM**: agent — global cross-project pattern library. "
+                "**READS**: decision tier — atomic choices this agent has recorded. "
+                "**USE AS STEP 1** in the anti-dupe protocol before calling "
+                "agent_log_decision; if a matching decision exists, update its outcome "
+                "via agent_update_decision_outcome rather than creating a duplicate."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -868,7 +964,17 @@ class LeanMCPInterface:
 
         registry["agent_log_learning"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_log_learning),
-            "description": "Log a learning or knowledge item discovered by an agent",
+            "description": (
+                "Log a reusable pattern this agent has discovered. "
+                "**SYSTEM**: agent — global cross-project pattern library; agent_name "
+                "MUST match ~/.claude/agents/{type}/{name}.md (validated; raises "
+                "AgentNotFoundError on typo). "
+                "**TIER**: learning — reusable pattern with when/how-to-apply guidance. "
+                "**ANTI-DUPE**: call agent_query_learnings(agent_name=X, "
+                "learning_type=Y) FIRST; if a similar pattern exists, update its "
+                "outcome stats via agent_update_learning_outcome instead of logging "
+                "a duplicate."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -914,6 +1020,12 @@ class LeanMCPInterface:
             },
             "examples": [
                 {
+                    "_workflow_hint": "STEP 1: query existing learnings before logging",
+                    "agent_name": "focused-quality-resolver",
+                    "learning_type": "pattern",
+                },
+                {
+                    "_workflow_hint": "STEP 2: log only if no matching learning found above",
                     "agent_name": "focused-quality-resolver",
                     "learning_type": "pattern",
                     "title": "Ruff handles import sorting",
@@ -921,13 +1033,20 @@ class LeanMCPInterface:
                     "applicability": ["python-projects", "lint-workflows"],
                     "confidence": 0.95,
                     "tags": ["python", "tooling"],
-                }
+                },
             ],
         }
 
         registry["agent_query_learnings"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_query_learnings),
-            "description": "Query learnings for an agent with optional filters",
+            "description": (
+                "Query reusable patterns logged for an agent across all projects. "
+                "**SYSTEM**: agent — global cross-project pattern library. "
+                "**READS**: learning tier — reusable patterns this agent has recorded. "
+                "**USE AS STEP 1** in the anti-dupe protocol before calling "
+                "agent_log_learning; if a similar pattern exists, update its stats "
+                "via agent_update_learning_outcome rather than creating a duplicate."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -993,7 +1112,15 @@ class LeanMCPInterface:
 
         registry["agent_create_notebook"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_create_notebook),
-            "description": "Create a notebook document for an agent",
+            "description": (
+                "Create a reasoning narrative notebook for this agent. "
+                "**SYSTEM**: agent — global cross-project pattern library; agent_name "
+                "MUST match ~/.claude/agents/{type}/{name}.md (validated). "
+                "**TIER**: notebook — reasoning narrative recording abandoned paths, "
+                "hypotheses, and context that lets future readers judge whether stored "
+                "decisions/learnings are still valid. Use agent_query_notebooks first "
+                "to avoid duplicate notebook records for the same work."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -1014,7 +1141,13 @@ class LeanMCPInterface:
                         "type": "string",
                         "default": "execution",
                         "description": (
-                            "Type of notebook (e.g., 'execution', 'analysis', 'retrospective')"
+                            "Notebook category. Canonical values: 'execution' (chronicle of "
+                            "work done), 'research' (investigation/exploration), 'learning' "
+                            "(reasoning narrative for a discovered pattern). Default: "
+                            "'execution'. NOTE: this differs from the 'learning' entity — a "
+                            "notebook of type 'learning' is the NARRATIVE explaining how/why "
+                            "a learning was discovered; a learning entity is the atomic "
+                            "pattern itself."
                         ),
                     },
                     "context": {"type": "object", "description": "Additional context metadata"},
@@ -1038,19 +1171,32 @@ class LeanMCPInterface:
             },
             "examples": [
                 {
+                    "_workflow_hint": "STEP 1: query existing notebooks to avoid duplicates",
+                    "agent_name": "focused-quality-resolver",
+                    "notebook_type": "execution",
+                },
+                {
+                    "_workflow_hint": "STEP 2: create notebook only if no recent one exists",
                     "agent_name": "focused-quality-resolver",
                     "title": "Quality Resolution Session - 2025-01-05",
                     "content": "## Summary\n\nFixed 15 lint issues...",
                     "summary": "Resolved lint issues in src/module.py",
                     "notebook_type": "execution",
                     "tags": ["quality", "python"],
-                }
+                },
             ],
         }
 
         registry["agent_query_notebooks"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_query_notebooks),
-            "description": "Query notebooks for an agent with optional filters",
+            "description": (
+                "Query reasoning narrative notebooks logged for an agent. "
+                "**SYSTEM**: agent — global cross-project pattern library. "
+                "**READS**: notebook tier — narrative records of this agent's work. "
+                "**USE AS STEP 1** in the anti-dupe protocol before calling "
+                "agent_create_notebook; filter by notebook_type and tags to find "
+                "existing narratives for the current work context."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -1081,7 +1227,15 @@ class LeanMCPInterface:
 
         registry["agent_search_all"] = {
             "implementation": self._wrap_async_tool(self.session_engine.agent_search_all),
-            "description": "Search across all agent data (decisions, learnings, notebooks)",
+            "description": (
+                "Search across all data for an agent: decisions, learnings, and notebooks. "
+                "**SYSTEM**: agent — global cross-project pattern library. "
+                "**READS**: all three tiers simultaneously for the named agent. "
+                "**USE AS STEP 1** in the anti-dupe protocol when you are unsure which "
+                "tier to check — a single call surfaces matches across decisions, "
+                "learnings, and notebooks so you can extend or supersede rather than "
+                "create duplicates."
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -1130,6 +1284,63 @@ class LeanMCPInterface:
                 return {"error": str(e), "tool": async_tool_func.__name__}
 
         return wrapper
+
+    def _discover_tools(self, pattern: str = "") -> dict[str, Any]:
+        """
+        Core implementation of the discover_tools meta-tool.
+
+        Extracted as a method so it can be called directly in tests without
+        going through the FastMCP tool dispatcher.
+        """
+        tools = []
+
+        for name, info in self.tool_registry.items():
+            # Apply pattern filter if provided
+            if pattern and pattern.strip() and pattern.lower() not in name.lower():
+                continue
+
+            tools.append({"name": name, "description": info["description"]})
+
+        result: dict[str, Any] = {
+            "available_tools": tools,
+            "total_tools": len(self.tool_registry),
+            "filtered_count": len(tools),
+        }
+        if not pattern:
+            result["_framework_guide"] = {
+                "systems": {
+                    "session_*": (
+                        "Project-scoped work history. Use when recording what was tried "
+                        "on a SPECIFIC project. Bind to project_name explicitly."
+                    ),
+                    "agent_*": (
+                        "Global cross-project agent pattern library. Use when refining "
+                        "how YOU (the agent) approach a class of problem regardless of "
+                        "project. agent_name is validated against "
+                        "~/.claude/agents/{type}/{name}.md."
+                    ),
+                    "knowledge_*": "Cross-project searchable knowledge base.",
+                },
+                "data_tiers": {
+                    "decision": "Atomic choice — what was decided. Queryable, valid-now.",
+                    "learning": "Reusable pattern — when/how to apply.",
+                    "notebook": (
+                        "Reasoning narrative — abandoned paths, hypotheses, the context "
+                        "that lets future readers judge whether stored decisions/learnings "
+                        "are still valid."
+                    ),
+                },
+                "anti_dupe_protocol": (
+                    "Before logging, QUERY existing tools (session_search, session_recall, "
+                    "agent_query_*) for matching content. Re-logging the same fact creates "
+                    "duplicates that pollute future retrievals."
+                ),
+                "project_name_discipline": (
+                    "Every session_* write tool accepts project_name. Pass it EXPLICITLY "
+                    "— the silent _unbound_ fallback corrupts retrieval (see PR #17)."
+                ),
+            }
+        return result
 
     def _setup_meta_tools(self):
         """Setup the 3 meta-tools for dynamic discovery."""
@@ -1208,20 +1419,7 @@ class LeanMCPInterface:
             MISSING TOOL? If you need an operation that's not available:
             File an issue at https://github.com/MementoRC/session-intelligence
             """
-            tools = []
-
-            for name, info in self.tool_registry.items():
-                # Apply pattern filter if provided
-                if pattern and pattern.strip() and pattern.lower() not in name.lower():
-                    continue
-
-                tools.append({"name": name, "description": info["description"]})
-
-            return {
-                "available_tools": tools,
-                "total_tools": len(self.tool_registry),
-                "filtered_count": len(tools),
-            }
+            return self._discover_tools(pattern)
 
         @self.app.tool(
             description=(

--- a/tests/unit/test_lean_mcp_descriptions.py
+++ b/tests/unit/test_lean_mcp_descriptions.py
@@ -1,0 +1,161 @@
+"""Regression test for tool description framing.
+
+Each registered tool's description must communicate: which system, which
+data tier, and (for write tools) anti-dupe guidance. This test catches
+description rewrites that drop the framing model.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lean_mcp_interface import LeanMCPInterface
+
+
+@pytest.fixture
+def interface():
+    """Build interface with mock engine."""
+    engine = MagicMock()
+    return LeanMCPInterface(engine)
+
+
+SESSION_TOOLS = {
+    "session_log_decision",
+    "session_log_learning",
+    "session_create_notebook",
+    "session_query_notebooks",
+    "session_recall",
+    "session_search",
+}
+
+AGENT_TOOLS = {
+    "agent_register",
+    "agent_log_decision",
+    "agent_log_learning",
+    "agent_create_notebook",
+    "agent_query_decisions",
+    "agent_query_learnings",
+    "agent_query_notebooks",
+    "agent_search_all",
+}
+
+WRITE_TOOLS = {
+    "session_log_decision",
+    "session_log_learning",
+    "session_create_notebook",
+    "agent_register",
+    "agent_log_decision",
+    "agent_log_learning",
+    "agent_create_notebook",
+}
+
+
+@pytest.mark.parametrize("tool_name", sorted(SESSION_TOOLS))
+def test_session_tool_description_mentions_system(interface, tool_name):
+    desc = interface.tool_registry[tool_name]["description"]
+    assert "SYSTEM" in desc and "session" in desc.lower(), (
+        f"{tool_name} description missing session-system framing"
+    )
+
+
+@pytest.mark.parametrize("tool_name", sorted(AGENT_TOOLS))
+def test_agent_tool_description_mentions_system(interface, tool_name):
+    desc = interface.tool_registry[tool_name]["description"]
+    assert "SYSTEM" in desc and "agent" in desc.lower(), (
+        f"{tool_name} description missing agent-system framing"
+    )
+
+
+# agent_register is a registry-identity operation; it writes to the agent
+# registry itself (not a data tier), so TIER/READS are not expected there.
+TIER_EXEMPT_TOOLS = {"agent_register"}
+
+
+@pytest.mark.parametrize("tool_name", sorted((SESSION_TOOLS | AGENT_TOOLS) - TIER_EXEMPT_TOOLS))
+def test_tool_description_mentions_tier(interface, tool_name):
+    desc = interface.tool_registry[tool_name]["description"]
+    assert "TIER" in desc or "READS" in desc, (
+        f"{tool_name} description missing TIER or READS tag"
+    )
+
+
+@pytest.mark.parametrize("tool_name", sorted(WRITE_TOOLS))
+def test_write_tool_description_includes_anti_dupe_hint(interface, tool_name):
+    desc = interface.tool_registry[tool_name]["description"]
+    desc_lower = desc.lower()
+    # Accept any of: explicit ANTI-DUPE tag, "query" (query-first protocol),
+    # or "check if already" (registry idempotency wording used by agent_register).
+    assert (
+        "ANTI-DUPE" in desc
+        or "anti-dupe" in desc_lower
+        or "query" in desc_lower
+        or "check if already" in desc_lower
+    ), f"{tool_name} (write) description missing anti-dupe / query-first hint"
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    sorted({"session_log_decision", "session_log_learning", "session_create_notebook"}),
+)
+def test_session_write_tool_mentions_project_scope_discipline(interface, tool_name):
+    """Session write tools must mention project scoping (project_name or project_path)."""
+    desc = interface.tool_registry[tool_name]["description"]
+    # Accept either spelling — both express the same bind-to-project discipline
+    assert "project_name" in desc or "project_path" in desc or "project" in desc.lower(), (
+        f"{tool_name} description missing project-scope discipline reminder"
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    sorted({"agent_register", "agent_log_decision", "agent_log_learning", "agent_create_notebook"}),
+)
+def test_agent_write_tool_mentions_validation(interface, tool_name):
+    desc = interface.tool_registry[tool_name]["description"]
+    assert (
+        "~/.claude/agents" in desc
+        or "AgentNotFoundError" in desc
+        or "validated" in desc.lower()
+    ), f"{tool_name} description missing agent-name validation reminder"
+
+
+def test_discover_tools_includes_framework_guide_on_bare_call(interface):
+    result = interface._discover_tools(pattern="")
+    assert "_framework_guide" in result, "discover_tools() bare call missing _framework_guide"
+    guide = result["_framework_guide"]
+    assert "systems" in guide
+    assert "data_tiers" in guide
+    assert "anti_dupe_protocol" in guide
+    assert "project_name_discipline" in guide
+    assert "session_*" in guide["systems"]
+    assert "agent_*" in guide["systems"]
+    assert "decision" in guide["data_tiers"]
+    assert "learning" in guide["data_tiers"]
+    assert "notebook" in guide["data_tiers"]
+
+
+def test_discover_tools_omits_framework_guide_on_filtered_call(interface):
+    result = interface._discover_tools(pattern="agent")
+    assert "_framework_guide" not in result, (
+        "_framework_guide should be absent when caller filters by pattern"
+    )
+
+
+def test_write_tool_examples_include_workflow_hint(interface):
+    """Write tools should have at least one example with _workflow_hint."""
+    for tool_name in sorted(WRITE_TOOLS):
+        examples = interface.tool_registry[tool_name].get("examples", [])
+        has_hint = any(
+            "_workflow_hint" in (ex if isinstance(ex, dict) else {}) for ex in examples
+        )
+        assert has_hint, f"{tool_name} examples missing _workflow_hint workflow guidance"
+
+
+def test_notebook_type_description_distinguishes_entity_from_narrative(interface):
+    """The notebook_type field for agent_create_notebook should clarify it's not the same
+    as the 'learning' entity."""
+    schema = interface.tool_registry["agent_create_notebook"]["schema"]
+    nt_desc = schema["properties"]["notebook_type"]["description"]
+    assert "narrative" in nt_desc.lower() or "entity" in nt_desc.lower(), (
+        f"notebook_type description should clarify entity-vs-narrative distinction; got: {nt_desc}"
+    )


### PR DESCRIPTION
## Summary

Description-only rewrite of the 14 `session_*` / `agent_*` tools in `src/lean_mcp_interface.py` plus a new `_framework_guide` block in `discover_tools` responses. Teaches the **two-system / three-tier** semantic model at the meta-tool layer so callers stop creating duplicates and stop tagging notebooks under wrong projects.

Follows up on PR #19 (agent-name validation), which added the filesystem enforcement that these descriptions now reference.

## What's the model?

**Two parallel sub-systems**
- `session_*` — project-scoped work history (bound to `project_name`)
- `agent_*` — global cross-project agent pattern library (bound to `agent_name`, validated against `~/.claude/agents/{type}/{name}.md`)

**Three data tiers within each system**
- `decision` — atomic choice (what was decided)
- `learning` — reusable pattern (when/how to apply)
- `notebook` — reasoning narrative (abandoned paths, hypotheses, the context that lets future readers judge whether stored decisions/learnings are still valid)

## Changes

1. **`discover_tools()`** — bare calls (no pattern) now return a `_framework_guide` block naming systems, data tiers, anti-dupe protocol, and project_name discipline. Filtered calls keep the lean response. ~165 tokens added to bare responses; agents typically `discover_tools` once per task.

2. **14 tool descriptions rewritten** with explicit `**SYSTEM**` / `**TIER**` (or `**READS**` for query tools) markers, anti-dupe hint, and project_name / agent-name discipline reminders.

3. **Write tools' `examples`** now include a synthetic `_workflow_hint` key on each entry showing the discover-then-log workflow as a 2-step chain. Not a real schema field — it's a strong nudge that travels in the example payload.

4. **`notebook_type`** field description for `agent_create_notebook` enumerates canonical values (execution / research / learning) and clarifies that a notebook of type 'learning' is the NARRATIVE explaining a discovered pattern — distinct from the 'learning' atomic entity. No enum constraint added (backward compat).

5. **`_discover_tools`** extracted as a proper method so it can be unit-tested without poking FastMCP internals. Closure delegates.

## Tests

`tests/unit/test_lean_mcp_descriptions.py` — **45 parametrized regression cases**:
- Each tool description contains the right SYSTEM / TIER (or READS) markers
- Write tools carry anti-dupe language
- Session write tools mention `project_name` discipline
- Agent write tools reference `~/.claude/agents` validation
- `_framework_guide` is gated on bare `discover_tools()` calls (absent on filtered calls)
- Write tool examples include `_workflow_hint`
- `notebook_type` description distinguishes entity from narrative

All 45 pass.

## Backward Compat

- No schema `required` changes
- No enum value renames
- No engine logic changes
- No new tools added
- Existing examples preserved (augmented, not replaced)

## Test Plan

- [ ] CI runs `pixi run test-unit` and reports green (full suite)
- [ ] CI lint passes on `src/lean_mcp_interface.py` and the new test file
- [ ] Spot-check: bare `discover_tools()` returns `_framework_guide`; `discover_tools(pattern='agent')` does not
- [ ] Spot-check: `get_tool_spec('session_log_decision')` description contains `**SYSTEM**: session` and `project_name` discipline reminder
- [ ] Spot-check: `get_tool_spec('agent_log_learning')` description references `~/.claude/agents`

## Follow-up

- **PR B (next)**: Flexible session identifier resolver — `_resolve_session_context(session_id?, session_name?, project_name?)` accepting any of three. Removes silent `_unbound_` fallback and adds the structural primitive that makes the description discipline easy to follow.