### PR TITLE
fix(engine): gate pre-resolver guard on in-process flag to stop stale-cache leak

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -143,6 +143,11 @@ class SessionIntelligenceEngine:
         self.use_filesystem = use_filesystem
         self.database = database  # Optional database for persistence
         self._current_session_id: str | None = None
+        # True only when THIS process explicitly created or adopted a session.
+        # Disk-loaded (stale) session IDs leave this False so the pre-resolver
+        # guard in session_log_decision (and peers) does not silently bind to
+        # a 5-day-old session from a previous server run.
+        self._current_session_set_in_process: bool = False
 
         # Use provided repository path or auto-detect project directory
         if repository_path:
@@ -490,6 +495,7 @@ class SessionIntelligenceEngine:
         # Cache session in memory
         self.session_cache[session_id] = session
         self._current_session_id = session_id
+        self._current_session_set_in_process = True  # in-process creation
 
         # Only create filesystem artifacts if enabled
         if self.use_filesystem:
@@ -1095,9 +1101,12 @@ class SessionIntelligenceEngine:
 
             decision_id = f"decision-{uuid.uuid4().hex[:8]}"
 
-            # If no identifier given but a current session exists in cache,
-            # thread it as session_id so the resolver validates rather than
-            # falling through to the unbound path.
+            # If no identifier given but a current session was created by THIS
+            # process, thread it as session_id so the resolver validates rather
+            # than falling through to the unbound path.  The guard is gated on
+            # _current_session_set_in_process so that a stale session ID loaded
+            # from disk at startup does NOT silently hijack the call — that
+            # would defeat the SessionContextRequiredError guarantee.
             effective_session_id = session_id
             if (
                 effective_session_id is None
@@ -1106,6 +1115,7 @@ class SessionIntelligenceEngine:
                 and not allow_unbound
                 and self._current_session_id
                 and self._current_session_id in self.session_cache
+                and self._current_session_set_in_process
             ):
                 effective_session_id = self._current_session_id
 

--- a/tests/unit/test_pre_resolver_guard.py
+++ b/tests/unit/test_pre_resolver_guard.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for the pre-resolver guard in session_log_decision.
+
+Verifies that _current_session_set_in_process correctly gates the guard so
+that a stale disk-cached session ID does NOT silently hijack calls that
+provide no explicit identifier (leak mode 1) and does NOT override an
+explicit project_name/session_id (leak mode 2).
+"""
+
+import pytest
+
+from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory SQLite database, initialized and cleaned up per test."""
+    backend = SQLiteBackend(db_path=":memory:")
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+def engine(db, monkeypatch: pytest.MonkeyPatch) -> SessionIntelligenceEngine:
+    """Engine wired to in-memory SQLite, no filesystem."""
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", "/tmp/nonexistent-agents")
+    return SessionIntelligenceEngine(
+        repository_path=None,
+        use_filesystem=False,
+        database=db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreResolverGuard:
+    async def test_no_identifier_after_cold_start_raises(self, engine, db):
+        """
+        Leak mode 1: After a server restart the engine loads a stale session
+        ID from disk into _current_session_id WITHOUT setting the in-process
+        flag.  A no-identifier call must raise SessionContextRequiredError
+        rather than silently binding to the stale session.
+        """
+        # Simulate disk-load: set _current_session_id directly (no flag)
+        engine._current_session_id = "stale-from-disk-20260418-170137"
+        assert engine._current_session_set_in_process is False
+
+        with pytest.raises(SessionContextRequiredError):
+            await engine.session_log_decision(decision="some decision")
+
+    async def test_no_identifier_after_in_process_create_continues(self, engine, db):
+        """
+        Happy path: when THIS process explicitly created a session via
+        _create_session, both _current_session_id and _current_session_set_in_process
+        are set.  A no-identifier call should bind to that session and succeed.
+        """
+        # Create a real session so FK persists correctly
+        result = engine._create_session(
+            mode="local",
+            project_name="test-project",
+            metadata={},
+            session_name=None,
+        )
+        assert result.status == "success"
+        await db.save_session(result.session_data.model_dump(mode="python"))
+
+        # Both fields must be set by _create_session
+        assert engine._current_session_id == result.session_id
+        assert engine._current_session_set_in_process is True
+
+        # No identifier passed — guard should fire and use current session
+        decision_result = await engine.session_log_decision(
+            decision="a decision without explicit identifier"
+        )
+        assert decision_result.decision_id != "error"
+        assert decision_result.session_id == result.session_id
+
+    async def test_explicit_project_name_overrides_stale_current(self, engine, db):
+        """
+        Leak mode 2: Even with a stale _current_session_id (disk-loaded, no
+        in-process flag), passing project_name must route through the resolver
+        and bind to a new/existing session for that project — NOT the stale one.
+        """
+        # Simulate disk-load
+        engine._current_session_id = "stale-id-should-not-be-used"
+        assert engine._current_session_set_in_process is False
+
+        # Call with explicit project_name; resolver creates a fresh session
+        decision_result = await engine.session_log_decision(
+            decision="decision with project_name",
+            project_name="myproject",
+        )
+        assert decision_result.decision_id != "error"
+        # The resolved session must NOT be the stale one
+        assert decision_result.session_id != "stale-id-should-not-be-used"
+
+    async def test_explicit_session_id_overrides_stale_current(self, engine, db):
+        """
+        Explicit session_id always wins regardless of _current_session_id state.
+        """
+        # Create a real session to pass to session_log_decision
+        result = engine._create_session(
+            mode="local",
+            project_name="proj-explicit",
+            metadata={},
+        )
+        assert result.status == "success"
+        await db.save_session(result.session_data.model_dump(mode="python"))
+        real_sid = result.session_id
+
+        # Overwrite current session with a stale one (no flag)
+        engine._current_session_id = "stale-id-should-not-be-used"
+        engine._current_session_set_in_process = False
+
+        decision_result = await engine.session_log_decision(
+            decision="decision with explicit session_id",
+            session_id=real_sid,
+        )
+        assert decision_result.decision_id != "error"
+        assert decision_result.session_id == real_sid


### PR DESCRIPTION
## Problem

`session_log_decision` has a pre-resolver guard (added to preserve the "continue current session" pattern) that uses `self._current_session_id` if no explicit identifier was passed. Two leak modes were discovered in live testing of PR #21:

### Leak Mode 1 — No-identifier call after server restart

`_current_session_id` is loaded from disk cache at startup with a stale (e.g. 5-day-old) session. The guard binds to it instead of raising `SessionContextRequiredError`. This **defeats PR #21's headline guarantee** that callers without an explicit identifier get a clear error.

### Leak Mode 2 — Guard hijacks explicit-identifier paths

Even with `project_name` supplied, the guard ran **before** the resolver and injected the stale `_current_session_id` as `effective_session_id`, bypassing the resolver entirely and binding to the wrong session.

For comparison: `session_log_learning` has no pre-resolver guard and raises `SessionContextRequiredError` correctly — the defect was **specific to `session_log_decision`'s guard**.

## Fix

Add `_current_session_set_in_process: bool = False` to `SessionIntelligenceEngine.__init__`. Set it `True` only in `_create_session()` — the in-process session creation path. Disk-loaded session IDs (from `_get_or_create_current_session_id`) leave it `False`.

Gate the pre-resolver guard on the new flag:

```python
# Before:
if (
    effective_session_id is None
    and session_name is None
    and project_name is None
    and not allow_unbound
    and self._current_session_id
    and self._current_session_id in self.session_cache
):
    effective_session_id = self._current_session_id

# After:
if (
    effective_session_id is None
    and session_name is None
    and project_name is None
    and not allow_unbound
    and self._current_session_id
    and self._current_session_id in self.session_cache
    and self._current_session_set_in_process  # only if THIS process created it
):
    effective_session_id = self._current_session_id
```

## Files Changed

- `src/core/session_engine.py` (+10 lines): add flag to `__init__`, set it in `_create_session`, gate the guard
- `tests/unit/test_pre_resolver_guard.py` (+130 lines): 4 new tests covering both leak modes and happy paths

## Tests

4 new tests in `tests/unit/test_pre_resolver_guard.py`:

1. `test_no_identifier_after_cold_start_raises` — disk-loaded stale `_current_session_id` (no in-process flag) + no identifier → `SessionContextRequiredError`
2. `test_no_identifier_after_in_process_create_continues` — `_create_session()` sets both fields → no-identifier call succeeds and binds to that session
3. `test_explicit_project_name_overrides_stale_current` — stale `_current_session_id` + explicit `project_name` → resolver runs, fresh session created, NOT the stale one
4. `test_explicit_session_id_overrides_stale_current` — stale `_current_session_id` + explicit `session_id` → that session_id wins

Parent: PR #21