### PR TITLE
fix(engine, persistence): partition learnings by project_name (closes #23)

### DIFF
--- a/scripts/migrations/backfill_project_learnings_project_name.py
+++ b/scripts/migrations/backfill_project_learnings_project_name.py
@@ -1,0 +1,160 @@
+"""Backfill project_learnings.project_name from source_session_id → sessions.project_name.
+
+Idempotent — only updates rows where project_name IS NULL.
+Run after the fix/issue-23-project-name-on-learnings PR is deployed to
+retroactively make old rows recallable via project_name.
+
+Usage (PostgreSQL):
+    PYTHONPATH=src python scripts/migrations/backfill_project_learnings_project_name.py
+
+Usage (SQLite):
+    PYTHONPATH=src python scripts/migrations/backfill_project_learnings_project_name.py \
+        --backend sqlite [--db-path /path/to/sessions.db]
+
+Environment variables:
+    DATABASE_URL  PostgreSQL DSN (default: postgresql://localhost/session_intelligence)
+    SQLITE_PATH   SQLite DB path (default: ~/.claude/session-intelligence/sessions.db)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def backfill_postgresql(dsn: str) -> None:
+    """Run the backfill on a PostgreSQL database."""
+    try:
+        import asyncpg
+    except ImportError:
+        logger.error("asyncpg is required for PostgreSQL. Install with: pip install asyncpg")
+        sys.exit(1)
+
+    logger.info(f"Connecting to PostgreSQL: {dsn}")
+    conn = await asyncpg.connect(dsn)
+    try:
+        # Count rows to be updated
+        null_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM project_learnings WHERE project_name IS NULL"
+        )
+        logger.info(f"Rows with project_name IS NULL: {null_count}")
+
+        # Backfill: update project_name from source_session_id → sessions.project_name
+        result = await conn.execute(
+            """
+            UPDATE project_learnings pl
+            SET project_name = s.project_name
+            FROM sessions s
+            WHERE pl.source_session_id = s.id
+              AND pl.project_name IS NULL
+              AND s.project_name IS NOT NULL
+            """
+        )
+        updated = int(result.split()[-1]) if result else 0
+        logger.info(f"Updated {updated} rows with project_name from sessions")
+
+        # Count still-null rows (no valid source_session_id)
+        still_null = await conn.fetchval(
+            "SELECT COUNT(*) FROM project_learnings WHERE project_name IS NULL"
+        )
+        logger.info(
+            f"Rows still NULL after backfill (no valid source_session_id): {still_null}"
+        )
+        logger.info("Backfill complete (PostgreSQL).")
+    finally:
+        await conn.close()
+
+
+async def backfill_sqlite(db_path: str) -> None:
+    """Run the backfill on a SQLite database."""
+    try:
+        import aiosqlite
+    except ImportError:
+        logger.error("aiosqlite is required for SQLite. Install with: pip install aiosqlite")
+        sys.exit(1)
+
+    logger.info(f"Opening SQLite database: {db_path}")
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+
+        # Count rows to be updated
+        cursor = await conn.execute(
+            "SELECT COUNT(*) FROM project_learnings WHERE project_name IS NULL"
+        )
+        row = await cursor.fetchone()
+        null_count = row[0] if row else 0
+        logger.info(f"Rows with project_name IS NULL: {null_count}")
+
+        # Backfill
+        cursor = await conn.execute(
+            """
+            UPDATE project_learnings
+            SET project_name = (
+                SELECT s.project_name
+                FROM sessions s
+                WHERE s.id = project_learnings.source_session_id
+                  AND s.project_name IS NOT NULL
+                LIMIT 1
+            )
+            WHERE project_name IS NULL
+              AND source_session_id IS NOT NULL
+            """
+        )
+        updated = cursor.rowcount
+        await conn.commit()
+        logger.info(f"Updated {updated} rows with project_name from sessions")
+
+        cursor = await conn.execute(
+            "SELECT COUNT(*) FROM project_learnings WHERE project_name IS NULL"
+        )
+        row = await cursor.fetchone()
+        still_null = row[0] if row else 0
+        logger.info(
+            f"Rows still NULL after backfill (no valid source_session_id): {still_null}"
+        )
+        logger.info("Backfill complete (SQLite).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill project_learnings.project_name from sessions table."
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["postgresql", "sqlite"],
+        default="postgresql",
+        help="Database backend to target (default: postgresql)",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="SQLite database file path (overrides SQLITE_PATH env var)",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help="PostgreSQL DSN (overrides DATABASE_URL env var)",
+    )
+    args = parser.parse_args()
+
+    if args.backend == "postgresql":
+        dsn = args.dsn or os.environ.get(
+            "DATABASE_URL", "postgresql://localhost/session_intelligence"
+        )
+        asyncio.run(backfill_postgresql(dsn))
+    else:
+        from pathlib import Path
+
+        default_path = Path.home() / ".claude" / "session-intelligence" / "sessions.db"
+        db_path = args.db_path or os.environ.get("SQLITE_PATH", str(default_path))
+        asyncio.run(backfill_sqlite(db_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -10,6 +10,7 @@ import json
 import logging
 import secrets
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -107,6 +108,20 @@ class SessionContextRequiredError(ValueError):
     """Raised when a session_* write tool is called without any session identifier."""
 
 
+@dataclass(frozen=True)
+class ResolvedSessionContext:
+    """Full context returned by _resolve_session_context.
+
+    Carries session_id plus the resolved session's project metadata so callers
+    can use the correct project_name / project_path without re-deriving them
+    from engine state.
+    """
+
+    session_id: str
+    project_name: str | None
+    project_path: str | None
+
+
 class SessionIntelligenceEngine:
     """
     Core session intelligence engine providing unified session management,
@@ -189,7 +204,7 @@ class SessionIntelligenceEngine:
         *,
         allow_unbound: bool = False,
         create_if_missing: bool = True,
-    ) -> str:
+    ) -> "ResolvedSessionContext":
         """Resolve a session ID from a flexible identifier set.
 
         Priority: session_id (exact) > session_name (scoped to project) >
@@ -201,11 +216,19 @@ class SessionIntelligenceEngine:
         The legacy `_unbound_` fallback is reachable only via allow_unbound=True
         or via _get_or_create_current_session_id (kept for back-compat in code
         paths that don't go through the resolver).
+
+        Returns:
+            ResolvedSessionContext with session_id, project_name, project_path
+            populated from the resolved session row.
         """
         # 1. session_id: trust caller, validate
         if session_id is not None:
             if not self.database:
-                return session_id  # no DB to validate against; trust it
+                return ResolvedSessionContext(
+                    session_id=session_id,
+                    project_name=None,
+                    project_path=None,
+                )
             existing = await self.database.get_session(session_id)
             if existing is None:
                 raise ValueError(
@@ -213,7 +236,11 @@ class SessionIntelligenceEngine:
                 )
             # Cache for back-compat
             self._current_session_id = session_id
-            return session_id
+            return ResolvedSessionContext(
+                session_id=session_id,
+                project_name=existing.get("project_name"),
+                project_path=existing.get("project_path"),
+            )
 
         # 2. session_name (optionally scoped to project_name)
         if session_name is not None:
@@ -227,7 +254,11 @@ class SessionIntelligenceEngine:
             )
             if match is not None:
                 self._current_session_id = match["id"]
-                return match["id"]
+                return ResolvedSessionContext(
+                    session_id=match["id"],
+                    project_name=match.get("project_name"),
+                    project_path=match.get("project_path"),
+                )
             if not create_if_missing:
                 raise ValueError(
                     f"session_name={session_name!r} not found "
@@ -240,7 +271,12 @@ class SessionIntelligenceEngine:
                 metadata={"session_name": session_name},
                 session_name=session_name,
             )
-            return result.session_id
+            cached = self.session_cache.get(result.session_id)
+            return ResolvedSessionContext(
+                session_id=result.session_id,
+                project_name=cached.project_name if cached else project_name,
+                project_path=cached.project_path if cached else None,
+            )
 
         # 3. project_name: find most-recent active OR create new
         if project_name is not None:
@@ -250,7 +286,11 @@ class SessionIntelligenceEngine:
                 )
                 if match is not None:
                     self._current_session_id = match["id"]
-                    return match["id"]
+                    return ResolvedSessionContext(
+                        session_id=match["id"],
+                        project_name=match.get("project_name"),
+                        project_path=match.get("project_path"),
+                    )
             if not create_if_missing:
                 raise ValueError(
                     f"no active session for project_name={project_name!r}"
@@ -260,11 +300,22 @@ class SessionIntelligenceEngine:
                 project_name=project_name,
                 metadata={},
             )
-            return result.session_id
+            cached = self.session_cache.get(result.session_id)
+            return ResolvedSessionContext(
+                session_id=result.session_id,
+                project_name=project_name,
+                project_path=cached.project_path if cached else None,
+            )
 
         # All three None
         if allow_unbound:
-            return self._get_or_create_current_session_id()  # legacy path
+            fallback_id: str = self._get_or_create_current_session_id() or ""  # legacy path
+            cached = self.session_cache.get(fallback_id) if fallback_id else None
+            return ResolvedSessionContext(
+                session_id=fallback_id,
+                project_name=cached.project_name if cached else None,
+                project_path=cached.project_path if cached else None,
+            )
 
         raise SessionContextRequiredError(
             "session_log_*, session_create_notebook require at least one of: "
@@ -1120,12 +1171,13 @@ class SessionIntelligenceEngine:
                 effective_session_id = self._current_session_id
 
             # Resolve session via the flexible resolver
-            resolved_id = await self._resolve_session_context(
+            resolved = await self._resolve_session_context(
                 session_id=effective_session_id,
                 session_name=session_name,
                 project_name=project_name,
                 allow_unbound=allow_unbound,
             )
+            resolved_id = resolved.session_id
             # Persist newly-created session to DB if needed
             if resolved_id and resolved_id not in (session_id or ""):
                 cached = self.session_cache.get(resolved_id)
@@ -1460,12 +1512,13 @@ class SessionIntelligenceEngine:
         """
         try:
             if session_id is None:
-                session_id = await self._resolve_session_context(
+                resolved = await self._resolve_session_context(
                     session_id=None,
                     session_name=session_name,
                     project_name=project_name,
                     allow_unbound=allow_unbound,
                 )
+                session_id = resolved.session_id
             return await self._create_notebook_impl(
                 session_id,
                 title,
@@ -1504,12 +1557,13 @@ class SessionIntelligenceEngine:
         try:
             # Resolve session via the flexible resolver
             if session_id is None:
-                session_id = await self._resolve_session_context(
+                resolved = await self._resolve_session_context(
                     session_id=None,
                     session_name=session_name,
                     project_name=project_name,
                     allow_unbound=allow_unbound,
                 )
+                session_id = resolved.session_id
             if not session_id or session_id not in self.session_cache:
                 return NotebookResult(
                     session_id=session_id or "unknown",
@@ -2516,9 +2570,6 @@ class SessionIntelligenceEngine:
         import uuid
 
         learning_id = f"learn_{uuid.uuid4().hex[:12]}"
-        effective_project = (
-            project_path or str(self.claude_sessions_path.parent)
-        )
 
         # Resolve session context
         # When the caller provides an explicit session identifier, use the
@@ -2526,14 +2577,16 @@ class SessionIntelligenceEngine:
         # no explicit identifier, skip the resolver and use _current_session_id
         # directly as the FK candidate — the FK validation block below will
         # check whether it actually exists in the DB and null it out if not.
+        resolved_ctx: ResolvedSessionContext | None = None
         resolved_session_id: str | None = None
         if session_id or session_name or project_name:
-            resolved_session_id = await self._resolve_session_context(
+            resolved_ctx = await self._resolve_session_context(
                 session_id=session_id,
                 session_name=session_name,
                 project_name=project_name,
                 allow_unbound=allow_unbound,
             )
+            resolved_session_id = resolved_ctx.session_id
             # Persist newly-created session to DB if needed
             if resolved_session_id:
                 cached = self.session_cache.get(resolved_session_id)
@@ -2555,6 +2608,19 @@ class SessionIntelligenceEngine:
                 "session_id, session_name, project_name. "
                 "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
             )
+
+        # Caller-supplied project_name takes priority; otherwise use the
+        # resolved session's project_name.
+        effective_project_name: str | None = project_name or (
+            resolved_ctx.project_name if resolved_ctx else None
+        )
+
+        # project_path: caller-supplied wins, then resolved session, then cwd fallback.
+        effective_project = (
+            project_path
+            or (resolved_ctx.project_path if resolved_ctx else None)
+            or str(self.claude_sessions_path.parent)
+        )
 
         source_session = resolved_session_id
 
@@ -2588,6 +2654,7 @@ class SessionIntelligenceEngine:
                 await self.database.save_project_learning(
                     learning_id=learning_id,
                     project_path=effective_project,
+                    project_name=effective_project_name,
                     category=(
                         category.value
                         if hasattr(category, "value")

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -206,6 +206,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
     CREATE TABLE IF NOT EXISTS project_learnings (
         id TEXT PRIMARY KEY,
         project_path TEXT NOT NULL,
+        project_name TEXT,
         category TEXT NOT NULL,
         trigger_context TEXT,
         learning_content TEXT NOT NULL,
@@ -218,6 +219,8 @@ class PostgreSQLBackend(BaseDatabaseBackend):
     );
 
     CREATE INDEX IF NOT EXISTS idx_learnings_project ON project_learnings(project_path);
+    CREATE INDEX IF NOT EXISTS idx_learnings_project_name ON project_learnings(project_name)
+        WHERE project_name IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_learnings_category ON project_learnings(category);
     CREATE INDEX IF NOT EXISTS idx_learnings_promoted ON project_learnings(promoted_to_universal);
 
@@ -385,6 +388,14 @@ class PostgreSQLBackend(BaseDatabaseBackend):
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_sessions_session_name "
                 "ON sessions(session_name) WHERE session_name IS NOT NULL"
+            )
+            await conn.execute(
+                "ALTER TABLE project_learnings "
+                "ADD COLUMN IF NOT EXISTS project_name TEXT"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_learnings_project_name "
+                "ON project_learnings(project_name) WHERE project_name IS NOT NULL"
             )
 
         self._is_connected = True
@@ -1124,29 +1135,26 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 ]
 
             if include_all or "learnings" in include:
-                path_row = await conn.fetchrow(
+                rows = await conn.fetch(
                     """
-                    SELECT project_path FROM sessions
-                    WHERE project_name = $1 AND project_path IS NOT NULL
-                    LIMIT 1
+                    SELECT id, category, trigger_context, learning_content,
+                           project_name, source_session_id, success_count,
+                           failure_count, created_at, last_used
+                    FROM project_learnings
+                    WHERE project_name = $1
+                       OR (project_name IS NULL AND project_path = (
+                           SELECT project_path FROM sessions
+                           WHERE project_name = $1
+                             AND project_path IS NOT NULL
+                           LIMIT 1
+                       ))
+                    ORDER BY success_count DESC, last_used DESC
+                    LIMIT $2
                     """,
                     project_name,
+                    limit,
                 )
-                if path_row:
-                    rows = await conn.fetch(
-                        """
-                        SELECT id, category, trigger_context, learning_content,
-                               source_session_id, success_count, failure_count,
-                               created_at, last_used
-                        FROM project_learnings
-                        WHERE project_path = $1
-                        ORDER BY success_count DESC, last_used DESC
-                        LIMIT $2
-                        """,
-                        path_row["project_path"],
-                        limit,
-                    )
-                    result["learnings"] = [self._from_record(row) for row in rows]
+                result["learnings"] = [self._from_record(row) for row in rows]
 
             if include_all or "notebooks" in include:
                 rows = await conn.fetch(
@@ -1436,6 +1444,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         learning_content: str,
         trigger_context: str | None = None,
         source_session_id: str | None = None,
+        project_name: str | None = None,
     ) -> dict[str, Any]:
         """Save a project-specific learning."""
         pool = self._ensure_connected()
@@ -1444,17 +1453,19 @@ class PostgreSQLBackend(BaseDatabaseBackend):
             await conn.execute(
                 """
                 INSERT INTO project_learnings (
-                    id, project_path, category, trigger_context, learning_content,
-                    source_session_id, success_count, failure_count, last_used,
-                    promoted_to_universal, created_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, 1, 0, NOW(), FALSE, NOW())
+                    id, project_path, project_name, category, trigger_context,
+                    learning_content, source_session_id, success_count, failure_count,
+                    last_used, promoted_to_universal, created_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, 1, 0, NOW(), FALSE, NOW())
                 ON CONFLICT(id) DO UPDATE SET
                     learning_content = EXCLUDED.learning_content,
                     trigger_context = EXCLUDED.trigger_context,
+                    project_name = EXCLUDED.project_name,
                     last_used = NOW()
                 """,
                 learning_id,
                 project_path,
+                project_name,
                 category,
                 trigger_context,
                 learning_content,

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -166,6 +166,7 @@ class SQLiteBackend(BaseDatabaseBackend):
     CREATE TABLE IF NOT EXISTS project_learnings (
         id TEXT PRIMARY KEY,
         project_path TEXT NOT NULL,
+        project_name TEXT,                -- Project name for direct recall (added in v3)
         category TEXT NOT NULL,           -- 'error_fix', 'pattern', 'preference', 'workflow'
         trigger_context TEXT,             -- What situation triggers this knowledge
         learning_content TEXT NOT NULL,   -- The actual knowledge/solution
@@ -179,6 +180,7 @@ class SQLiteBackend(BaseDatabaseBackend):
     );
 
     CREATE INDEX IF NOT EXISTS idx_learnings_project ON project_learnings(project_path);
+    CREATE INDEX IF NOT EXISTS idx_learnings_project_name ON project_learnings(project_name);
     CREATE INDEX IF NOT EXISTS idx_learnings_category ON project_learnings(category);
     CREATE INDEX IF NOT EXISTS idx_learnings_promoted ON project_learnings(promoted_to_universal);
 
@@ -367,6 +369,26 @@ class SQLiteBackend(BaseDatabaseBackend):
             await self._connection.commit()
         except Exception as e:
             logger.debug(f"session_name index creation: {e}")
+
+        # Idempotent migration: add project_name column to project_learnings
+        try:
+            await self._connection.execute(
+                "ALTER TABLE project_learnings ADD COLUMN project_name TEXT"
+            )
+            await self._connection.commit()
+        except Exception as e:
+            if "duplicate column" not in str(e).lower():
+                raise
+
+        # Add index for project_name on project_learnings
+        try:
+            await self._connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_learnings_project_name "
+                "ON project_learnings(project_name)"
+            )
+            await self._connection.commit()
+        except Exception as e:
+            logger.debug(f"project_learnings project_name index creation: {e}")
 
         self._is_connected = True
         logger.info(f"SQLite database initialized: {self.db_path}")
@@ -1502,6 +1524,7 @@ class SQLiteBackend(BaseDatabaseBackend):
         learning_content: str,
         trigger_context: str | None = None,
         source_session_id: str | None = None,
+        project_name: str | None = None,
     ) -> dict[str, Any]:
         """Save a project-specific learning."""
         conn = self._ensure_connected()
@@ -1510,18 +1533,20 @@ class SQLiteBackend(BaseDatabaseBackend):
         await conn.execute(
             """
             INSERT INTO project_learnings (
-                id, project_path, category, trigger_context, learning_content,
-                source_session_id, success_count, failure_count, last_used,
-                promoted_to_universal, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, 1, 0, ?, FALSE, ?)
+                id, project_path, project_name, category, trigger_context,
+                learning_content, source_session_id, success_count, failure_count,
+                last_used, promoted_to_universal, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, 0, ?, FALSE, ?)
             ON CONFLICT(id) DO UPDATE SET
                 learning_content = excluded.learning_content,
                 trigger_context = excluded.trigger_context,
+                project_name = excluded.project_name,
                 last_used = excluded.last_used
         """,
             (
                 learning_id,
                 project_path,
+                project_name,
                 category,
                 trigger_context,
                 learning_content,
@@ -1738,6 +1763,127 @@ class SQLiteBackend(BaseDatabaseBackend):
             "success_rate": new_rate,
             "updated": True,
         }
+
+    async def recall_project(
+        self,
+        project_name: str,
+        include: list[str] | None = None,
+        limit: int = 10,
+        days: int = 30,
+        query: str | None = None,
+    ) -> dict[str, Any]:
+        """Recall recent sessions, decisions, learnings, and notebooks for a project."""
+        from datetime import UTC, datetime, timedelta
+
+        conn = self._ensure_connected()
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+        include_all = include is None
+        result: dict[str, Any] = {
+            "project_name": project_name,
+            "recall_window_days": days,
+            "sessions": [],
+            "decisions": [],
+            "learnings": [],
+            "notebooks": [],
+        }
+
+        if include_all or "sessions" in include:
+            cursor = await conn.execute(
+                """
+                SELECT id, started_at, ended_at, status, mode
+                FROM sessions
+                WHERE project_name = ? AND started_at > ?
+                ORDER BY started_at DESC
+                LIMIT ?
+                """,
+                (project_name, cutoff, limit),
+            )
+            rows = await cursor.fetchall()
+            result["sessions"] = [
+                {
+                    "id": row["id"],
+                    "started_at": row["started_at"],
+                    "status": row["status"],
+                }
+                for row in rows
+            ]
+
+        if include_all or "decisions" in include:
+            cursor = await conn.execute(
+                """
+                SELECT d.id, d.description, d.category, d.rationale,
+                       d.impact_level, d.timestamp, s.id AS session_id
+                FROM decisions d
+                JOIN sessions s ON d.session_id = s.id
+                WHERE s.project_name = ? AND d.timestamp > ?
+                ORDER BY d.timestamp DESC
+                LIMIT ?
+                """,
+                (project_name, cutoff, limit),
+            )
+            rows = await cursor.fetchall()
+            result["decisions"] = [
+                {
+                    "description": row["description"],
+                    "category": row["category"],
+                    "rationale": row["rationale"],
+                    "timestamp": row["timestamp"],
+                }
+                for row in rows
+            ]
+
+        if include_all or "learnings" in include:
+            cursor = await conn.execute(
+                """
+                SELECT id, category, trigger_context, learning_content,
+                       project_name, source_session_id, success_count,
+                       failure_count, created_at, last_used
+                FROM project_learnings
+                WHERE project_name = ?
+                   OR (project_name IS NULL AND project_path = (
+                       SELECT project_path FROM sessions
+                       WHERE project_name = ?
+                         AND project_path IS NOT NULL
+                       LIMIT 1
+                   ))
+                ORDER BY success_count DESC, last_used DESC
+                LIMIT ?
+                """,
+                (project_name, project_name, limit),
+            )
+            rows = await cursor.fetchall()
+            result["learnings"] = [dict(row) for row in rows]
+
+        if include_all or "notebooks" in include:
+            cursor = await conn.execute(
+                """
+                SELECT ss.title, ss.tags, ss.created_at, ss.session_id
+                FROM session_summaries ss
+                JOIN sessions s ON ss.session_id = s.id
+                WHERE s.project_name = ? AND ss.created_at > ?
+                ORDER BY ss.created_at DESC
+                LIMIT ?
+                """,
+                (project_name, cutoff, limit),
+            )
+            rows = await cursor.fetchall()
+            result["notebooks"] = [
+                {
+                    "title": row["title"],
+                    "tags": self._deserialize_json(row["tags"]),
+                    "created_at": row["created_at"],
+                    "session_id": row["session_id"],
+                }
+                for row in rows
+            ]
+
+        result["counts"] = {
+            "sessions": len(result["sessions"]),
+            "decisions": len(result["decisions"]),
+            "learnings": len(result["learnings"]),
+            "notebooks": len(result["notebooks"]),
+        }
+        return result
 
     # Maintenance operations
 

--- a/tests/regression/test_issue_23_project_name_on_learnings.py
+++ b/tests/regression/test_issue_23_project_name_on_learnings.py
@@ -1,0 +1,256 @@
+"""
+Regression tests for issue #23: session_log_learning ignores explicit project_name.
+
+Verifies the two-layer fix:
+  Layer A — _resolve_session_context returns ResolvedSessionContext with
+            project_name / project_path from the resolved session row.
+  Layer B — project_learnings.project_name column is persisted and used by
+            recall_project for direct filtering (with path-bridge fallback for
+            legacy rows where project_name IS NULL).
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from core.session_engine import ResolvedSessionContext, SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory SQLite database, initialized and cleaned up per test."""
+    backend = SQLiteBackend(db_path=":memory:")
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+def engine(db, monkeypatch: pytest.MonkeyPatch) -> SessionIntelligenceEngine:
+    """Engine wired to in-memory SQLite, no filesystem."""
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", "/tmp/nonexistent-agents")
+    return SessionIntelligenceEngine(
+        repository_path=None,
+        use_filesystem=False,
+        database=db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+async def _create_and_persist(engine, db, project_name, session_name=None):
+    """Create a session in the engine cache and persist it to the DB."""
+    result = engine._create_session(
+        mode="local",
+        project_name=project_name,
+        metadata={},
+        session_name=session_name,
+    )
+    assert result.status == "success"
+    await db.save_session(result.session_data.model_dump(mode="python"))
+    return result.session_id
+
+
+# ---------------------------------------------------------------------------
+# Test 1: explicit project_name round-trips through log → recall
+# ---------------------------------------------------------------------------
+
+
+async def test_log_learning_with_explicit_project_name_recalls_correctly(engine, db):
+    """
+    session_log_learning(project_name="proj-A", ...) must make the learning
+    recallable via session_recall(project_name="proj-A").
+
+    The engine's repository_path is None (cwd-derived path would be wrong).
+    The only way the learning shows up in recall is if project_name is persisted
+    on the row and recall_project uses it directly.
+    """
+    learn_result = await engine.session_log_learning(
+        category="pattern",
+        learning_content="use dataclasses for frozen value objects",
+        trigger_context="refactoring session context",
+        project_name="proj-A",
+    )
+    assert learn_result.status == "saved", f"save failed: {learn_result.message}"
+
+    recall = await engine.session_recall(project_name="proj-A")
+    learnings = recall.get("learnings", [])
+    contents = [lr.get("learning_content", "") for lr in learnings]
+    assert any(
+        "dataclasses" in c for c in contents
+    ), f"learning not found in recall; learnings={learnings}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: session_id resolution propagates session's project_name
+# ---------------------------------------------------------------------------
+
+
+async def test_log_learning_with_session_id_uses_session_project_name(engine, db):
+    """
+    session_log_learning(session_id=X) with no explicit project_name must
+    persist the session's own project_name on the learning row so that
+    session_recall(project_name="proj-B") finds it.
+    """
+    sid = await _create_and_persist(engine, db, "proj-B")
+
+    learn_result = await engine.session_log_learning(
+        category="workflow",
+        learning_content="always run tests before commit",
+        session_id=sid,
+    )
+    assert learn_result.status == "saved"
+
+    # Verify the persisted row has project_name="proj-B"
+    conn = db._ensure_connected()
+    cursor = await conn.execute(
+        "SELECT project_name FROM project_learnings WHERE id = ?",
+        (learn_result.id,),
+    )
+    row = await cursor.fetchone()
+    assert row is not None
+    assert row["project_name"] == "proj-B"
+
+    # Recall must surface it
+    recall = await engine.session_recall(project_name="proj-B")
+    learnings = recall.get("learnings", [])
+    contents = [lr.get("learning_content", "") for lr in learnings]
+    assert any(
+        "commit" in c for c in contents
+    ), f"learning not found in recall; learnings={learnings}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: explicit project_name overrides session's project_name
+# ---------------------------------------------------------------------------
+
+
+async def test_log_learning_explicit_project_name_overrides_session_project_name(
+    engine, db
+):
+    """
+    When session_id is bound to proj-A but caller passes project_name="proj-C",
+    the persisted row's project_name must be "proj-C" (caller wins).
+    """
+    sid = await _create_and_persist(engine, db, "proj-A")
+
+    learn_result = await engine.session_log_learning(
+        category="preference",
+        learning_content="prefer ruff over flake8",
+        session_id=sid,
+        project_name="proj-C",
+    )
+    assert learn_result.status == "saved"
+
+    conn = db._ensure_connected()
+    cursor = await conn.execute(
+        "SELECT project_name FROM project_learnings WHERE id = ?",
+        (learn_result.id,),
+    )
+    row = await cursor.fetchone()
+    assert row is not None
+    assert row["project_name"] == "proj-C", (
+        f"expected proj-C but got {row['project_name']}"
+    )
+
+    # Recall via proj-C must find it
+    recall_c = await engine.session_recall(project_name="proj-C")
+    contents_c = [lr.get("learning_content", "") for lr in recall_c.get("learnings", [])]
+    assert any("ruff" in c for c in contents_c), f"learning not in proj-C recall: {recall_c}"
+
+    # Recall via proj-A must NOT find it (it was overridden)
+    recall_a = await engine.session_recall(project_name="proj-A")
+    contents_a = [lr.get("learning_content", "") for lr in recall_a.get("learnings", [])]
+    assert not any("ruff" in c for c in contents_a), (
+        f"learning should not appear in proj-A recall: {recall_a}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: legacy rows with project_name=NULL still recalled via path-bridge
+# ---------------------------------------------------------------------------
+
+
+async def test_recall_project_finds_legacy_rows_via_path_bridge(engine, db):
+    """
+    A learning row written before this fix (project_name=NULL, project_path set)
+    must still be surfaced by recall_project via the path-bridge fallback:
+      SELECT ... WHERE project_name IS NULL AND project_path = (
+          SELECT project_path FROM sessions WHERE project_name=$1 LIMIT 1
+      )
+    """
+    # Create a session with project_name="legacy-proj" and a known project_path
+    result = engine._create_session(
+        mode="local",
+        project_name="legacy-proj",
+        metadata={},
+    )
+    assert result.status == "success"
+    # Manually set a predictable project_path
+    session_data = result.session_data.model_dump(mode="python")
+    session_data["project_path"] = "/old/legacy/path"
+    await db.save_session(session_data)
+
+    # Manually insert a legacy learning row (project_name=NULL, project_path set)
+    conn = db._ensure_connected()
+    legacy_id = f"learn_{uuid.uuid4().hex[:12]}"
+    now = datetime.now(UTC).isoformat()
+    await conn.execute(
+        """
+        INSERT INTO project_learnings (
+            id, project_path, project_name, category, trigger_context,
+            learning_content, source_session_id, success_count, failure_count,
+            last_used, promoted_to_universal, created_at
+        ) VALUES (?, ?, NULL, ?, ?, ?, ?, 1, 0, ?, FALSE, ?)
+        """,
+        (
+            legacy_id,
+            "/old/legacy/path",
+            "error_fix",
+            "builds used to fail on CI",
+            "legacy fix: pin dependency X to 1.2.3",
+            result.session_id,
+            now,
+            now,
+        ),
+    )
+    await conn.commit()
+
+    # recall_project must find the legacy row via the path-bridge fallback
+    recall = await engine.session_recall(project_name="legacy-proj")
+    learnings = recall.get("learnings", [])
+    contents = [lr.get("learning_content", "") for lr in learnings]
+    assert any(
+        "pin dependency" in c for c in contents
+    ), f"legacy learning not found via path-bridge; learnings={learnings}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: _resolve_session_context returns full ResolvedSessionContext
+# ---------------------------------------------------------------------------
+
+
+async def test_resolved_context_returns_session_metadata(engine, db):
+    """
+    _resolve_session_context called with project_name="proj-X" must return a
+    ResolvedSessionContext with session_id, project_name="proj-X", and
+    project_path populated.
+    """
+    resolved = await engine._resolve_session_context(project_name="proj-X")
+
+    assert isinstance(resolved, ResolvedSessionContext)
+    assert resolved.session_id is not None
+    assert resolved.session_id != ""
+    assert resolved.project_name == "proj-X"
+    # project_path may be None or a string — just confirm the attribute exists
+    assert hasattr(resolved, "project_path")

--- a/tests/unit/test_session_resolver.py
+++ b/tests/unit/test_session_resolver.py
@@ -7,7 +7,11 @@ real filesystem state and PostgreSQL.
 
 import pytest
 
-from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine
+from core.session_engine import (
+    ResolvedSessionContext,
+    SessionContextRequiredError,
+    SessionIntelligenceEngine,
+)
 from persistence.sqlite import SQLiteBackend
 
 # ---------------------------------------------------------------------------
@@ -63,7 +67,8 @@ class TestResolveBySessionId:
         """Resolving by a known session_id returns that same id."""
         sid = await _create_and_persist(engine, db, "proj-a")
         resolved = await engine._resolve_session_context(session_id=sid)
-        assert resolved == sid
+        assert isinstance(resolved, ResolvedSessionContext)
+        assert resolved.session_id == sid
 
     async def test_resolve_by_session_id_unknown_raises(self, engine, db):
         """Resolving by a nonexistent session_id raises ValueError."""
@@ -76,7 +81,8 @@ class TestResolveBySessionName:
         """Resolving by name returns the id of the named session."""
         sid = await _create_and_persist(engine, db, "proj-b", session_name="my-debug-session")
         resolved = await engine._resolve_session_context(session_name="my-debug-session")
-        assert resolved == sid
+        assert isinstance(resolved, ResolvedSessionContext)
+        assert resolved.session_id == sid
 
     async def test_resolve_by_session_name_with_project_filter(self, engine, db):
         """When two sessions share a name in different projects, project_name scopes correctly."""
@@ -90,9 +96,9 @@ class TestResolveBySessionName:
             session_name="shared-name", project_name="proj-y"
         )
 
-        assert resolved_x == sid_a
-        assert resolved_y == sid_b
-        assert resolved_x != resolved_y
+        assert resolved_x.session_id == sid_a
+        assert resolved_y.session_id == sid_b
+        assert resolved_x.session_id != resolved_y.session_id
 
     async def test_resolve_by_session_name_creates_when_missing_and_create_if_missing_true(
         self, engine, db
@@ -102,11 +108,12 @@ class TestResolveBySessionName:
             session_name="brand-new-session",
             create_if_missing=True,
         )
-        assert resolved is not None
-        assert resolved != ""
+        assert isinstance(resolved, ResolvedSessionContext)
+        assert resolved.session_id is not None
+        assert resolved.session_id != ""
 
         # Verify persisted in cache
-        assert resolved in engine.session_cache
+        assert resolved.session_id in engine.session_cache
 
     async def test_resolve_by_session_name_raises_when_missing_and_create_if_missing_false(
         self, engine, db
@@ -132,7 +139,7 @@ class TestResolveByProjectName:
         sid_new = await _create_and_persist(engine, db, "proj-multi")
 
         resolved = await engine._resolve_session_context(project_name="proj-multi")
-        assert resolved == sid_new
+        assert resolved.session_id == sid_new
 
     async def test_resolve_by_project_name_creates_when_no_active(self, engine, db):
         """When no active session exists for a project, a new one is created."""
@@ -140,9 +147,10 @@ class TestResolveByProjectName:
             project_name="brand-new-project",
             create_if_missing=True,
         )
-        assert resolved is not None
-        assert resolved != ""
-        assert resolved in engine.session_cache
+        assert isinstance(resolved, ResolvedSessionContext)
+        assert resolved.session_id is not None
+        assert resolved.session_id != ""
+        assert resolved.session_id in engine.session_cache
 
 
 class TestResolveAllNone:
@@ -155,8 +163,9 @@ class TestResolveAllNone:
         """allow_unbound=True falls back to _get_or_create_current_session_id."""
         resolved = await engine._resolve_session_context(allow_unbound=True)
         # Should return a valid session id (not raise)
-        assert resolved is not None
-        assert resolved != ""
+        assert isinstance(resolved, ResolvedSessionContext)
+        assert resolved.session_id is not None
+        assert resolved.session_id != ""
 
 
 class TestResolvePriority:
@@ -172,4 +181,17 @@ class TestResolvePriority:
             session_name="other-name",
             project_name="other-proj",
         )
-        assert resolved == sid
+        assert resolved.session_id == sid
+
+
+class TestResolvedSessionContextFields:
+    async def test_resolve_returns_project_name_from_session(self, engine, db):
+        """Resolved context includes the session's project_name."""
+        sid = await _create_and_persist(engine, db, "proj-fields")
+        resolved = await engine._resolve_session_context(session_id=sid)
+        assert resolved.project_name == "proj-fields"
+
+    async def test_resolve_by_project_name_propagates_project_name(self, engine, db):
+        """Resolving by project_name populates project_name in the result."""
+        resolved = await engine._resolve_session_context(project_name="new-proj")
+        assert resolved.project_name == "new-proj"


### PR DESCRIPTION
## Problem

`session_log_learning(project_name="X", ...)` silently ignored the explicit `project_name` parameter and persisted rows under the engine's cwd-derived `project_path`. `session_recall` then filtered through a fragile two-step path-bridge that broke whenever the write-side `project_path` differed from what was recorded in the sessions table. Result: writes succeeded but recall returned empty.

## Two-Layer Fix

### Layer A — Resolver returns full context

`_resolve_session_context` now returns a `ResolvedSessionContext` dataclass (defined at module level in `session_engine.py`) instead of just a `str`:

```python
@dataclass(frozen=True)
class ResolvedSessionContext:
    session_id: str
    project_name: str | None
    project_path: str | None
```

Four callers updated: `session_log_decision`, `session_log_learning`, `session_create_notebook`, `session_create_notebook_async`. The resolved session's `project_name`/`project_path` is now propagated to `session_log_learning` so it can persist the correct identifier. Caller-supplied `project_name` always takes priority over the resolved session's value.

### Layer B — Schema + writer + reader

- **`project_learnings` gains a `project_name TEXT` column** in both PostgreSQL and SQLite SCHEMA definitions.
- **Idempotent migrations** on both backends: `ALTER TABLE project_learnings ADD COLUMN IF NOT EXISTS project_name TEXT` (PG) and the `try/except duplicate column` pattern (SQLite).
- **`save_project_learning`** updated on both backends to accept and persist `project_name`.
- **`recall_project` learnings query** now filters by `project_name` directly with the legacy path-bridge kept as a fallback for rows where `project_name IS NULL`.
- **`recall_project` added to `SQLiteBackend`** — it was missing entirely (engine delegates to it; tests use SQLite).

### Backfill Script

`scripts/migrations/backfill_project_learnings_project_name.py` — idempotent UPDATE that populates `project_name` for existing rows by JOINing `source_session_id → sessions.project_name`. Supports both PostgreSQL and SQLite.

## Tests

5 new regression tests in `tests/regression/test_issue_23_project_name_on_learnings.py`:
1. Explicit `project_name` write-recall round-trip across cwd contexts
2. `session_id` resolution propagates session's `project_name` to the row
3. Caller-supplied `project_name` overrides session's `project_name`
4. Legacy rows (`project_name IS NULL`) recalled via path-bridge fallback
5. `_resolve_session_context` returns populated `ResolvedSessionContext`

`tests/unit/test_session_resolver.py` updated (7 assertions) for the new return type + 2 new field-population tests added.

Closes #23.