### PR TITLE
fix(engine): auto-bind session for unrecognized session_id in track_execution (closes #33)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -532,9 +532,20 @@ class SessionIntelligenceEngine:
         project_name: str,
         metadata: dict[str, Any],
         session_name: str | None = None,
+        session_id: str | None = None,
     ) -> SessionResult:
-        """Create a new session with comprehensive setup."""
-        session_id = f"session-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(3)}"
+        """Create a new session with comprehensive setup.
+
+        If `session_id` is provided, it is used verbatim as the cache/DB key
+        instead of minting a `session-...` id. This lets callers bind a
+        session to an externally-supplied identifier (e.g. Claude Code's
+        native subagent session UUID) so later lookups by that same id hit
+        the cache instead of failing.
+        """
+        session_id = (
+            session_id
+            or f"session-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(3)}"
+        )
 
         # Create session metadata
         session_metadata = SessionMetadata(
@@ -847,18 +858,39 @@ class SessionIntelligenceEngine:
             )
 
         if session_id not in self.session_cache:
-            debug_logger.error(f"ERROR: session_id {session_id} not in cache")
-            debug_logger.error(
-                f"Available sessions: {list(self.session_cache.keys())}"
+            debug_logger.info(
+                f"session_id {session_id} not in cache; auto-creating and "
+                "binding a session-intelligence session to it (likely a "
+                "hook-supplied Claude Code native session id)"
             )
-            return ExecutionTrackingResult(
-                step_id="error",
+            create_result = self._create_session(
+                mode="auto",
+                project_name="_unbound_",
+                metadata={
+                    "project_path": step_data.get(
+                        "working_directory", str(Path.cwd().resolve())
+                    ),
+                    "tags": ["hook-bound", "claude-native-session"],
+                },
+                session_name=None,
                 session_id=session_id,
-                agent_name=agent_name,
-                status="error-session-not-found",
-                patterns_detected=[],
-                optimizations=[],
             )
+            if create_result.status != "success":
+                debug_logger.error(
+                    f"ERROR: failed to auto-create session for {session_id}: "
+                    f"{create_result.message}"
+                )
+                debug_logger.error(
+                    f"Available sessions: {list(self.session_cache.keys())}"
+                )
+                return ExecutionTrackingResult(
+                    step_id="error",
+                    session_id=session_id,
+                    agent_name=agent_name,
+                    status="error-session-not-found",
+                    patterns_detected=[],
+                    optimizations=[],
+                )
 
         session = self.session_cache[session_id]
         debug_logger.info(f"Found session in cache: {session.id}")

--- a/tests/regression/test_issue_33_hook_session_binding.py
+++ b/tests/regression/test_issue_33_hook_session_binding.py
@@ -1,0 +1,116 @@
+"""
+Regression tests for issue #33: hook-supplied Claude Code native session
+UUIDs are rejected by execution tracking because they were never created
+via `session_manage_lifecycle create`.
+
+https://github.com/Claire-s-Monster/session-intelligence/issues/33
+
+Verifies the fix:
+  `_track_execution_sync` no longer returns `status="error-session-not-found"`
+  on a cache miss. Instead it auto-creates and binds a session under the
+  externally-supplied `session_id` (via `_create_session(..., session_id=...)`)
+  so hook-driven callers (SubagentStart/SubagentStop) that pass a native
+  Claude Code session UUID succeed on first use and reuse the same cached
+  session on subsequent calls.
+"""
+
+import pytest
+
+from core.session_engine import SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+NATIVE_SESSION_ID = "cd2b76d0-37cc-4768-a466-2b61d3fd8947"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine(tmp_path, monkeypatch):
+    """SessionIntelligenceEngine wired to a fresh in-process SQLite backend.
+
+    Filesystem persistence is OFF - cache assertions are the focus of the
+    issue #33 fix verification.
+    """
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+
+    db = SQLiteBackend(db_path=str(tmp_path / "issue33.db"))
+    await db.initialize()
+
+    eng = SessionIntelligenceEngine(
+        repository_path=str(tmp_path),
+        use_filesystem=False,
+        database=db,
+    )
+    yield eng
+    await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #33: hook-supplied native session ids auto-bind instead of erroring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_hook_session_id_auto_binds_on_first_track_execution(engine):
+    """A native Claude Code session UUID that was never created via
+    `session_manage_lifecycle create` must auto-bind on first use instead
+    of failing with status='error-session-not-found'."""
+    result = engine.session_track_execution(
+        session_id=NATIVE_SESSION_ID,
+        agent_name="focused-code-modifier",
+        step_data={"operation": "start", "description": "SubagentStart hook"},
+    )
+
+    assert result.status != "error-session-not-found", (
+        "Hook-supplied native session id was rejected instead of being "
+        "auto-bound. This is issue #33."
+    )
+    assert result.status == "success"
+
+    assert NATIVE_SESSION_ID in engine.session_cache, (
+        "Native session id was not registered in session_cache after "
+        "auto-creation."
+    )
+
+    bound_session = engine.session_cache[NATIVE_SESSION_ID]
+    assert bound_session.id == NATIVE_SESSION_ID
+    assert "hook-bound" in bound_session.metadata.tags
+    assert "claude-native-session" in bound_session.metadata.tags
+
+
+@pytest.mark.regression
+async def test_hook_session_id_reused_on_second_track_execution(engine):
+    """Two calls with the same native session id (simulating SubagentStart
+    then SubagentStop) must reuse the exact same cached Session rather than
+    creating a duplicate or erroring on the second call."""
+    first_result = engine.session_track_execution(
+        session_id=NATIVE_SESSION_ID,
+        agent_name="focused-code-modifier",
+        step_data={"operation": "start", "description": "SubagentStart hook"},
+    )
+    assert first_result.status == "success"
+    assert NATIVE_SESSION_ID in engine.session_cache
+    first_session = engine.session_cache[NATIVE_SESSION_ID]
+
+    second_result = engine.session_track_execution(
+        session_id=NATIVE_SESSION_ID,
+        agent_name="focused-code-modifier",
+        step_data={"operation": "stop", "description": "SubagentStop hook"},
+    )
+    assert second_result.status == "success"
+    assert second_result.status != "error-session-not-found"
+
+    assert list(engine.session_cache.keys()).count(NATIVE_SESSION_ID) == 1
+    second_session = engine.session_cache[NATIVE_SESSION_ID]
+
+    assert second_session is first_session, (
+        "Second call to session_track_execution with the same native "
+        "session id created a distinct Session object instead of reusing "
+        "the cached one."
+    )
+    assert second_session.id == first_session.id
+    # Both hook calls should now be recorded as steps on the same session.
+    assert len(second_session.agents_executed) >= 1


### PR DESCRIPTION
Closes #33.

## Root cause

Claude Code's `SubagentStart`/`SubagentStop` hooks (`~/.claude/hooks/session_intelligence_agent_start.py`, `session_intelligence_agent_stop.py`) call `session_track_execution` passing Claude Code's own native session UUID (e.g. `cd2b76d0-37cc-4768-a466-2b61d3fd8947`) as `session_id`. `_track_execution_sync` only recognized session ids already present in `session_cache`, which are minted exclusively by `session_manage_lifecycle create` in a different format (`session-YYYYMMDD-HHMMSS-hex`). The native UUID never matched, so every hook-driven call returned `error-session-not-found` and `agent_executions` got zero rows from real hook-driven agent runs, even after #32.

## Fix

- `_create_session` now accepts an optional `session_id` override, used verbatim as the cache/DB key instead of always minting a new `session-...` id.
- `_track_execution_sync`, on encountering a `session_id` not in `session_cache`, now auto-creates and binds a session under that exact external id (tagged `hook-bound`, `claude-native-session`) instead of erroring — mirroring the existing auto-create behavior already used when `session_id` is empty. Falls back to `error-session-not-found` only if that create itself fails.

## Tests

Added `tests/regression/test_issue_33_hook_session_binding.py`:
- `test_hook_session_id_auto_binds_on_first_track_execution` — unrecognized native-UUID session_id succeeds and binds a session with the expected tags.
- `test_hook_session_id_reused_on_second_track_execution` — a second call with the same UUID (simulating the start/stop hook pairing) reuses the same cached session rather than erroring or duplicating.

Full `tests/regression/` suite: 23 passed, 0 failed.