### PR TITLE
fix(engine): transition AgentExecution status on agent_stop (closes #39)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -905,6 +905,17 @@ class SessionIntelligenceEngine:
         )
         debug_logger.info(f"Created step_id: {step_id}")
 
+        # The SubagentStop hook reports phase="agent_stop" with a "success"
+        # flag once an agent finishes. That is the only signal we have to
+        # transition an execution out of RUNNING into a terminal state.
+        is_agent_stop = step_data.get("phase") == "agent_stop"
+        terminal_status = (
+            ExecutionStatus.SUCCESS
+            if step_data.get("success")
+            else ExecutionStatus.ERROR
+        )
+        completed_at = datetime.now(UTC) if is_agent_stop else None
+
         execution_step = ExecutionStep(
             step_id=step_id,
             step_number=len(session.agents_executed) + 1,
@@ -913,7 +924,8 @@ class SessionIntelligenceEngine:
             description=step_data.get("description", ""),
             tools_used=step_data.get("tools_used", []),
             started=datetime.now(UTC),
-            status=ExecutionStatus.RUNNING,
+            completed=completed_at,
+            status=terminal_status if is_agent_stop else ExecutionStatus.RUNNING,
         )
         debug_logger.info(f"Created execution_step: {execution_step}")
 
@@ -958,6 +970,10 @@ class SessionIntelligenceEngine:
                 performance=AgentPerformance(),
             )
             session.agents_executed.append(agent_execution)
+
+        if is_agent_stop:
+            agent_execution.status = terminal_status
+            agent_execution.completed = completed_at
 
         # Add step to agent execution
         agent_execution.execution_steps.append(execution_step)

--- a/tests/regression/test_issue_39_agent_execution_status_transition.py
+++ b/tests/regression/test_issue_39_agent_execution_status_transition.py
@@ -1,0 +1,164 @@
+"""
+Regression tests for issue #39: AgentExecution status never transitions
+from RUNNING; successes/failures always 0 in session_agent_stats.
+
+https://github.com/Claire-s-Monster/session-intelligence/issues/39
+
+Verifies the fix:
+  `_track_execution_sync` now inspects `step_data["phase"]`. When the
+  SubagentStop hook reports `phase="agent_stop"`, the ExecutionStep and
+  the matching AgentExecution transition out of ExecutionStatus.RUNNING
+  into ExecutionStatus.SUCCESS (step_data["success"] truthy) or
+  ExecutionStatus.ERROR (falsy), with `completed` timestamps set.
+  Non-agent_stop phases (e.g. agent_start) continue to create/append
+  RUNNING steps unchanged.
+"""
+
+import pytest
+
+from core.session_engine import SessionIntelligenceEngine
+from models.session_models import ExecutionStatus
+from persistence.sqlite import SQLiteBackend
+
+AGENT_NAME = "focused-code-modifier"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine(tmp_path, monkeypatch):
+    """SessionIntelligenceEngine wired to a fresh in-process SQLite backend.
+
+    Filesystem persistence is OFF - in-memory AgentExecution/ExecutionStep
+    status assertions are the focus of the issue #39 fix verification.
+    """
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+
+    db = SQLiteBackend(db_path=str(tmp_path / "issue39.db"))
+    await db.initialize()
+
+    eng = SessionIntelligenceEngine(
+        repository_path=str(tmp_path),
+        use_filesystem=False,
+        database=db,
+    )
+    yield eng
+    await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #39: agent_stop phase transitions RUNNING -> SUCCESS/ERROR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_agent_stop_success_transitions_to_success_status(engine):
+    """A SubagentStart-like call followed by an agent_stop call with
+    success=True must transition the AgentExecution out of RUNNING into
+    SUCCESS, not leave it stuck at RUNNING."""
+    start_result = engine.session_track_execution(
+        session_id=None,
+        agent_name=AGENT_NAME,
+        step_data={"operation": "start", "description": "SubagentStart hook"},
+    )
+    assert start_result.status == "success"
+    session_id = start_result.session_id
+
+    session = engine.session_cache[session_id]
+    agent_execution = next(
+        a for a in session.agents_executed if a.agent_name == AGENT_NAME
+    )
+    assert agent_execution.status == ExecutionStatus.RUNNING
+
+    stop_result = engine.session_track_execution(
+        session_id=session_id,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_stop",
+            "agent_type": "focused",
+            "success": True,
+            "tools_used": ["Read", "Edit"],
+        },
+    )
+    assert stop_result.status == "success"
+
+    agent_execution = next(
+        a for a in session.agents_executed if a.agent_name == AGENT_NAME
+    )
+    assert agent_execution.status == ExecutionStatus.SUCCESS, (
+        "AgentExecution.status did not transition from RUNNING to SUCCESS "
+        "on agent_stop with success=True. This is issue #39."
+    )
+    assert agent_execution.completed is not None
+
+    last_step = agent_execution.execution_steps[-1]
+    assert last_step.status == ExecutionStatus.SUCCESS
+    assert last_step.completed is not None
+
+
+@pytest.mark.regression
+async def test_agent_stop_failure_transitions_to_error_status(engine):
+    """An agent_stop call with success=False must transition the
+    AgentExecution into ERROR, not leave it stuck at RUNNING."""
+    start_result = engine.session_track_execution(
+        session_id=None,
+        agent_name=AGENT_NAME,
+        step_data={"operation": "start", "description": "SubagentStart hook"},
+    )
+    session_id = start_result.session_id
+
+    stop_result = engine.session_track_execution(
+        session_id=session_id,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_stop",
+            "agent_type": "focused",
+            "success": False,
+            "error_count": 2,
+        },
+    )
+    assert stop_result.status == "success"
+
+    session = engine.session_cache[session_id]
+    agent_execution = next(
+        a for a in session.agents_executed if a.agent_name == AGENT_NAME
+    )
+    assert agent_execution.status == ExecutionStatus.ERROR, (
+        "AgentExecution.status did not transition from RUNNING to ERROR "
+        "on agent_stop with success=False. This is issue #39."
+    )
+    assert agent_execution.completed is not None
+
+    last_step = agent_execution.execution_steps[-1]
+    assert last_step.status == ExecutionStatus.ERROR
+
+
+@pytest.mark.regression
+async def test_non_agent_stop_phase_keeps_running_status(engine):
+    """Phases other than agent_stop (e.g. agent_start) must continue to
+    create/append RUNNING steps, unaffected by the agent_stop fix."""
+    start_result = engine.session_track_execution(
+        session_id=None,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_start",
+            "operation": "start",
+            "description": "SubagentStart hook",
+        },
+    )
+    assert start_result.status == "success"
+    session_id = start_result.session_id
+
+    session = engine.session_cache[session_id]
+    agent_execution = next(
+        a for a in session.agents_executed if a.agent_name == AGENT_NAME
+    )
+    assert agent_execution.status == ExecutionStatus.RUNNING
+    assert agent_execution.completed is None
+
+    last_step = agent_execution.execution_steps[-1]
+    assert last_step.status == ExecutionStatus.RUNNING
+    assert last_step.completed is None


### PR DESCRIPTION
## Summary
- `_track_execution_sync` never transitioned `AgentExecution`/`ExecutionStep` off the default `RUNNING` status, even though the SubagentStop hook sends `step_data.success`. Every persisted execution stayed `status="running"` forever, so `get_agent_stats`' successes/failures aggregation never matched and `success_rate` was always 0.0 regardless of real outcome.
- Now, when `step_data.phase == "agent_stop"`, both objects transition to `ExecutionStatus.SUCCESS`/`ExecutionStatus.ERROR` based on `step_data.success`, with a completion timestamp stamped. Other phases (e.g. `agent_start`) are unaffected.
- No changes needed in `sqlite.py`/`postgresql.py` — the aggregation logic already matched on `"success"`/`"error"` string literals; only the write side was broken.

Closes #39 (follow-on from #33/#38, which fixed session_id auto-binding but left this separate status-transition bug undiscovered until invocation counts became real).

## Test plan
- [x] New regression tests: `tests/regression/test_issue_39_agent_execution_status_transition.py` (3 tests: success transition, error transition, non-agent_stop phase stays RUNNING)
- [x] `pixi run --environment ci test` (full suite): 431 passed, 62 skipped, 3 failed — the 3 failures are pre-existing and unrelated (agent-validator strict-mode lookups against `~/.claude/agents` in `tests/integration/test_concurrency.py`, and a notes-migration count assertion in `tests/unit/test_migration.py`; neither touches `session_engine.py`'s execution-status code path)

🤖 Generated with Claude Code