### PR TITLE
fix(engine): backfill agent_type from cache when hook reports empty string (closes #41)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -155,6 +155,12 @@ class SessionIntelligenceEngine:
 
         self.session_cache: dict[str, Session] = {}
         self.pattern_cache: dict[str, list[PatternAnalysis]] = {}
+        # Caches the last known-real agent_type per agent_name so a later
+        # call (e.g. SubagentStop, which may report an empty string due to
+        # a Claude Code harness quirk) can recover the type observed on an
+        # earlier call (e.g. SubagentStart) for the same agent_name.
+        # See issue #41.
+        self._agent_type_cache: dict[str, str] = {}
         self.use_filesystem = use_filesystem
         self.database = database  # Optional database for persistence
         self._current_session_id: str | None = None
@@ -944,6 +950,20 @@ class SessionIntelligenceEngine:
         execution_step.patterns_detected = patterns
         execution_step.optimizations_available = optimizations
 
+        # Resolve agent_type, preferring a cached real value over an
+        # empty/"unknown" one reported on this particular call. See issue
+        # #41: the SubagentStop hook can report agent_type as "" (a
+        # present-but-falsy key) due to a Claude Code harness quirk, which
+        # `.get(key, default)` does not substitute a default for.
+        raw_agent_type = step_data.get("agent_type", "unknown")
+        if raw_agent_type and raw_agent_type != "unknown":
+            resolved_agent_type = raw_agent_type
+            self._agent_type_cache[agent_name] = raw_agent_type
+        else:
+            resolved_agent_type = self._agent_type_cache.get(
+                agent_name, raw_agent_type or "unknown"
+            )
+
         # Find or create agent execution
         agent_execution = None
         for agent_exec in session.agents_executed:
@@ -957,7 +977,7 @@ class SessionIntelligenceEngine:
 
             agent_execution = AgentExecution(
                 agent_name=agent_name,
-                agent_type=step_data.get("agent_type", "unknown"),
+                agent_type=resolved_agent_type,
                 execution_id=f"{agent_name}-{uuid.uuid4().hex[:8]}",
                 started=datetime.now(UTC),
                 context=AgentContext(
@@ -974,6 +994,11 @@ class SessionIntelligenceEngine:
         if is_agent_stop:
             agent_execution.status = terminal_status
             agent_execution.completed = completed_at
+            if resolved_agent_type != "unknown" and not (
+                agent_execution.agent_type
+                and agent_execution.agent_type != "unknown"
+            ):
+                agent_execution.agent_type = resolved_agent_type
 
         # Add step to agent execution
         agent_execution.execution_steps.append(execution_step)

--- a/tests/regression/test_issue_41_agent_type_resolution.py
+++ b/tests/regression/test_issue_41_agent_type_resolution.py
@@ -1,0 +1,200 @@
+"""
+Regression tests for issue #41: Majority of agent_executions have
+unresolved agent_type (raw hex ID instead of agent name).
+
+https://github.com/Claire-s-Monster/session-intelligence/issues/41
+
+Root cause: `_track_execution_sync` derived `agent_type` solely from
+`step_data.get("agent_type", "unknown")` at execution-creation time. The
+SubagentStop hook can report `agent_type` as `""` (a present-but-falsy
+key, not a missing one) due to a Claude Code harness quirk, and
+`.get(key, default)` does not substitute the default for a present
+falsy value. That empty string then persisted verbatim, and the
+read-side fallback in `get_agent_stats` (`agent_type or agent_name or
+"unknown"`) substituted the raw hex agent_name in its place.
+
+Verifies the fix:
+  `SessionIntelligenceEngine` now maintains an in-memory
+  `_agent_type_cache: dict[str, str]` keyed by `agent_name`. Whenever a
+  call reports a real (non-"unknown", non-falsy) `agent_type`, it is
+  cached. Whenever a call reports a falsy/"unknown" `agent_type`, the
+  cached value (if any) is preferred over persisting the falsy value.
+  On `phase="agent_stop"` calls that reuse an existing RUNNING
+  `AgentExecution`, a resolved real value backfills
+  `AgentExecution.agent_type` if the existing stored value is currently
+  falsy or "unknown" (never overwriting a real value with a worse one).
+"""
+
+import pytest
+
+from core.session_engine import SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+AGENT_NAME = "a9116be028f1d04d3"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine(tmp_path, monkeypatch):
+    """SessionIntelligenceEngine wired to a fresh in-process SQLite backend.
+
+    Filesystem persistence is OFF - in-memory AgentExecution agent_type
+    assertions are the focus of the issue #41 fix verification.
+    """
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+
+    db = SQLiteBackend(db_path=str(tmp_path / "issue41.db"))
+    await db.initialize()
+
+    eng = SessionIntelligenceEngine(
+        repository_path=str(tmp_path),
+        use_filesystem=False,
+        database=db,
+    )
+    yield eng
+    await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #41: agent_type resolution via in-memory cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+async def test_agent_stop_empty_agent_type_backfilled_from_cache(engine):
+    """A Start-phase call reporting a real agent_type, followed by a
+    Stop-phase call for the SAME agent_name reporting agent_type="" (the
+    harness quirk), must not persist the empty string. The cached real
+    value from the Start call must backfill the existing AgentExecution."""
+    start_result = engine.session_track_execution(
+        session_id=None,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_start",
+            "agent_type": "focused-code-modifier",
+            "operation": "start",
+            "description": "SubagentStart hook",
+        },
+    )
+    assert start_result.status == "success"
+    session_id = start_result.session_id
+
+    session = engine.session_cache[session_id]
+    agent_execution = next(
+        a for a in session.agents_executed if a.agent_name == AGENT_NAME
+    )
+    assert agent_execution.agent_type == "focused-code-modifier"
+
+    stop_result = engine.session_track_execution(
+        session_id=session_id,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_stop",
+            "agent_type": "",
+            "success": True,
+        },
+    )
+    assert stop_result.status == "success"
+
+    agent_execution = next(
+        a for a in session.agents_executed if a.agent_name == AGENT_NAME
+    )
+    assert agent_execution.agent_type == "focused-code-modifier", (
+        "AgentExecution.agent_type was overwritten with an empty string "
+        "reported by the SubagentStop hook instead of being backfilled "
+        "from the in-memory cache. This is issue #41."
+    )
+
+
+@pytest.mark.regression
+async def test_no_prior_cache_falls_back_to_unknown(engine):
+    """When no cache entry exists yet for a given agent_name and
+    step_data reports an empty/missing agent_type, the result must still
+    fall back to "unknown" - no silent substitution of a wrong value,
+    and no regression of existing pre-#41 behavior."""
+    result = engine.session_track_execution(
+        session_id=None,
+        agent_name="brand-new-agent-hexid",
+        step_data={
+            "phase": "agent_start",
+            "operation": "start",
+            "description": "SubagentStart hook",
+        },
+    )
+    assert result.status == "success"
+    session_id = result.session_id
+
+    session = engine.session_cache[session_id]
+    agent_execution = next(
+        a
+        for a in session.agents_executed
+        if a.agent_name == "brand-new-agent-hexid"
+    )
+    assert agent_execution.agent_type == "unknown"
+
+
+@pytest.mark.regression
+async def test_later_real_agent_type_updates_stale_cached_value(engine):
+    """If the same agent_name is later reused (a fresh, unrelated
+    invocation) with a genuinely different real agent_type on its own
+    Start-equivalent call, the cache must update to the newer real
+    value - last-real-value-wins, not stuck on the first-seen value."""
+    first_start = engine.session_track_execution(
+        session_id=None,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_start",
+            "agent_type": "focused-code-modifier",
+            "operation": "start",
+            "description": "first invocation",
+        },
+    )
+    session_id = first_start.session_id
+    session = engine.session_cache[session_id]
+
+    first_stop = engine.session_track_execution(
+        session_id=session_id,
+        agent_name=AGENT_NAME,
+        step_data={"phase": "agent_stop", "agent_type": "", "success": True},
+    )
+    assert first_stop.status == "success"
+
+    # A later, unrelated invocation of the same agent_name (e.g. the
+    # subagent was re-dispatched under a different role) reports a
+    # genuinely different real agent_type.
+    second_start = engine.session_track_execution(
+        session_id=session_id,
+        agent_name=AGENT_NAME,
+        step_data={
+            "phase": "agent_start",
+            "agent_type": "focused-quality-resolver",
+            "operation": "start",
+            "description": "second invocation",
+        },
+    )
+    assert second_start.status == "success"
+
+    second_execution = next(
+        a
+        for a in session.agents_executed
+        if a.agent_name == AGENT_NAME
+        and a.agent_type == "focused-quality-resolver"
+    )
+    assert second_execution.agent_type == "focused-quality-resolver"
+
+    second_stop = engine.session_track_execution(
+        session_id=session_id,
+        agent_name=AGENT_NAME,
+        step_data={"phase": "agent_stop", "agent_type": "", "success": True},
+    )
+    assert second_stop.status == "success"
+
+    assert engine._agent_type_cache[AGENT_NAME] == "focused-quality-resolver"
+    assert second_execution.agent_type == "focused-quality-resolver", (
+        "Stale first-seen cached agent_type leaked into a later, "
+        "unrelated invocation's backfill."
+    )


### PR DESCRIPTION
## Summary
- `_track_execution_sync` only ever set `AgentExecution.agent_type` from `step_data.get("agent_type", "unknown")` at creation time. `dict.get()` only substitutes the default for a MISSING key, not a present-but-falsy one — so when Claude Code's harness sends `agent_type` as `""` (observed on SubagentStop events), it passed straight through as an empty string. `get_agent_stats`' read-side fallback (`agent_type or agent_name or "unknown"`) then substituted the raw hex `agent_name`, which is why ~92% of `agent_executions` rows showed opaque hex IDs instead of real agent names.
- Fix: a process-lifetime `self._agent_type_cache` dict keyed by `agent_name` (stable across a subagent's Start/Stop hook calls, since `SessionIntelligenceEngine` is a process-lifetime singleton per `http_server.py`'s FastAPI lifespan). Any call with a real, non-"unknown" `agent_type` populates the cache; any call with an empty/unknown value consults it as a fallback — both at `AgentExecution` creation and when backfilling an existing execution on `agent_stop`. Never downgrades an already-real value.
- No async DB calls added to the sync `_track_execution_sync` path (the existing `agents` table / `get_agent_by_name()` registry is async and wasn't a clean fit). Read-side aggregation (`sqlite.py`/`postgresql.py`) untouched — already correct once the write side populates real values.

Closes #41 (third bug in the same `_track_execution_sync` telemetry chain as #33/#38 and #39/#40).

## Test plan
- [x] New regression tests: `tests/regression/test_issue_41_agent_type_resolution.py` (3 tests: Stop-phase empty string backfilled from Start-phase cache entry; no-prior-cache still falls back to "unknown"; last-real-value-wins on a later genuinely-different real type)
- [x] `pixi run --environment ci test` (full suite): 435 passed, 62 skipped, 2 failed — both are the same pre-existing agent-validator fixture-gap failures documented during #39's verification (`tests/integration/test_concurrency.py`, unrelated to this change)

🤖 Generated with Claude Code