### PR TITLE
fix(lean-interface): validate execute_tool params against declared schema

### DIFF
--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -1745,6 +1745,32 @@ class LeanMCPInterface:
                     "error": f"parameters must be a mapping, got {type(parameters).__name__}",
                 }
 
+            # Validate parameters against the declared schema before dispatch, so a
+            # mistyped name surfaces as an actionable error instead of a raw TypeError
+            # leaking out of the engine. Schemas without declared properties are not
+            # validated (nothing to check against).
+            schema = tool_info.get("schema") or {}
+            valid_params = set(schema.get("properties", {}))
+            if valid_params:
+                unknown = sorted(set(parameters) - valid_params)
+                missing = sorted(set(schema.get("required", [])) - set(parameters))
+                if unknown or missing:
+                    problems = []
+                    if unknown:
+                        problems.append(f"unexpected parameter(s): {unknown}")
+                    if missing:
+                        problems.append(f"missing required parameter(s): {missing}")
+                    return {
+                        "tool": tool_name,
+                        "status": "error",
+                        "error": (
+                            f"Invalid parameters for '{tool_name}' - "
+                            f"{'; '.join(problems)}. "
+                            f"Valid parameters: {sorted(valid_params)}. "
+                            f"Call get_tool_spec('{tool_name}') for the full schema."
+                        ),
+                    }
+
             try:
                 # Execute tool - await if async, call directly if sync
                 if inspect.iscoroutinefunction(tool_func):


### PR DESCRIPTION
## Problem

`execute_tool` dispatched `**parameters` straight through to the engine with no validation, so any caller typo surfaced as a raw Python `TypeError`. Observed in the service journal:

```
lean_mcp_interface - ERROR - Error in agent_register:
  SessionIntelligenceEngine.agent_register() got an unexpected keyword argument 'name'
```

That message names neither the correct parameter (`agent_name`) nor how to find it.

Note this was **not** a signature mismatch — the engine and the registry schema both agree on `agent_name`. The caller simply passed `name=`, and nothing in the dispatch path caught it.

## Fix

Validate parameters against the tool's declared schema before dispatch, returning an actionable error:

```
Invalid parameters for 'agent_register' - unexpected parameter(s): ['name'];
missing required parameter(s): ['agent_name'].
Valid parameters: ['agent_name', 'agent_type', 'capabilities', 'description',
'display_name', 'metadata'].
Call get_tool_spec('agent_register') for the full schema.
```

Schemas with no declared `properties` are skipped — there is nothing to validate against.

This implements behavior the `execute_tool` docstring **already documented** but which was never implemented:

> VALIDATION: Parameters are validated against the tool schema before execution. Unexpected parameters will be rejected with an error listing valid parameters.

Applies to all 30 registered tools, not just `agent_register`.

## Verification

```
501 collected · 437 passed · 62 skipped · 2 failed (47.23s)
ruff check src/lean_mcp_interface.py → All checks passed!
```

The 2 failures are the pre-existing agent-validator strict-mode fixture gap (`AgentNotFoundError: Agent 'shared-agent-name' not found`) in `tests/integration/test_concurrency.py`, unrelated to this change and untouched here.

## Risk

Rejecting undeclared parameters means any tool whose schema is *incomplete* relative to its implementation would begin failing calls that previously worked. The full suite is the guard, and it shows no such regression — but reviewers who know of a tool accepting undocumented parameters should flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)