### PR TITLE
docs: point issue-tracker URLs at Claire-s-Monster, not MementoRC

### DIFF
--- a/scripts/session-intelligence.service.example
+++ b/scripts/session-intelligence.service.example
@@ -1,6 +1,6 @@
 [Unit]
 Description=Session Intelligence MCP HTTP Server
-Documentation=https://github.com/MementoRC/session-intelligence
+Documentation=https://github.com/Claire-s-Monster/session-intelligence
 After=network.target postgresql.service
 Requires=postgresql.service
 

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -1533,7 +1533,7 @@ class LeanMCPInterface:
                 discover_tools("learning")      # Find learning/knowledge tools
 
             MISSING TOOL? If you need an operation that's not available:
-            File an issue at https://github.com/MementoRC/session-intelligence
+            File an issue at https://github.com/Claire-s-Monster/session-intelligence
             """
             return self._discover_tools(pattern)
 
@@ -1624,7 +1624,7 @@ class LeanMCPInterface:
 
             TOOL NOT FOUND? Use discover_tools() first to find available tools.
             If the tool should exist but doesn't, file a feature request at:
-            https://github.com/MementoRC/session-intelligence
+            https://github.com/Claire-s-Monster/session-intelligence
             """
             if tool_name not in self.tool_registry:
                 available_tools = list(self.tool_registry.keys())
@@ -1713,7 +1713,7 @@ class LeanMCPInterface:
             Call discover_tools(pattern) first to find the right tool for your task.
 
             FOUND A BUG OR MISSING FEATURE?
-            File an issue at https://github.com/MementoRC/session-intelligence
+            File an issue at https://github.com/Claire-s-Monster/session-intelligence
             Include: tool name, parameters used, error message, expected vs actual behavior
             """
             import inspect


### PR DESCRIPTION
## Problem

Four references still point at `github.com/MementoRC/session-intelligence`, stale from a repo move.

The worst offender is the **"FOUND A BUG OR MISSING FEATURE?"** text in the `execute_tool` docstring — that string is returned to every agent that calls the tool, so it actively routes bug reports to the wrong org. It also 404s if used as the owner for the GitHub API; that's how this was found (a `github_create_pr` call against `MementoRC` returned 404 while opening #45).

## Evidence the canonical repo is Claire-s-Monster

A repo-wide sweep found `Claire-s-Monster` 7x vs `MementoRC` 4x:

| Points at `Claire-s-Monster` | |
|---|---|
| `git remote get-url origin` | `https://github.com/Claire-s-Monster/session-intelligence.git` |
| `LICENSE:3` | `Copyright (c) 2026 Claire-s-Monster` |
| `.github/workflows/ci.yml:24` | `Claire-s-Monster/ci-framework/...` |
| `tests/regression/test_issue_25_finalize_persistence.py:5` | `.../issues/25` |
| `tests/regression/test_issue_33_hook_session_binding.py:6` | `.../issues/33` |
| `tests/regression/test_issue_39_agent_execution_status_transition.py:5` | `.../issues/39` |
| `tests/regression/test_issue_41_agent_type_resolution.py:5` | `.../issues/41` |

The regression tests are what make this conclusive rather than a judgment call: they cite specific issue numbers whose fixes are merged in this repo's own history (#33 hook session binding, #39 execution status, #41 agent_type resolution). Issues that exist and are cited by passing tests establish where the tracker lives.

`MementoRC` is a real org used elsewhere in this ecosystem, so a full sweep was run rather than assuming staleness — but no remaining `MementoRC` reference in this repo points anywhere other than `session-intelligence`.

## Changes

4 one-line replacements, doc/comment-only, no behavior change:

- `src/lean_mcp_interface.py:1536` — `discover_tools` docstring, MISSING TOOL?
- `src/lean_mcp_interface.py:1627` — `get_tool_spec` docstring, TOOL NOT FOUND?
- `src/lean_mcp_interface.py:1716` — `execute_tool` docstring, FOUND A BUG?
- `scripts/session-intelligence.service.example:3` — systemd `Documentation=`

## Verification

- Zero remaining `MementoRC` hits repo-wide (excluding `.git/`, `.pixi/`)
- `ast.parse` on `src/lean_mcp_interface.py`: OK
- `ruff check src/lean_mcp_interface.py`: All checks passed!

Full test suite not run — this touches only docstrings and a comment line. Rebased onto `development` after #45 merged; diff contains only these 4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)