### PR TITLE
test(concurrency): disable agent-name validation in local engine fixture

### DIFF
--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -32,8 +32,14 @@ async def db(tmp_path):
 
 
 @pytest.fixture
-async def engine(tmp_path, db):
+async def engine(tmp_path, db, monkeypatch):
     """Engine backed by the test SQLite database."""
+    # Disable agent-name validation so tests using synthetic names like
+    # "agent-concurrent-0" do not require matching files under ~/.claude/agents/.
+    # Mirrors the shared session_engine fixture in tests/conftest.py, which this
+    # fixture replaces in order to inject the SQLite backend.
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+
     eng = SessionIntelligenceEngine(
         repository_path=str(tmp_path),
         use_filesystem=False,


### PR DESCRIPTION
## Problem

`tests/integration/test_concurrency.py::test_concurrent_agent_registrations_all_succeed` and `::test_concurrent_agent_registrations_same_name_is_idempotent` fail with `AgentNotFoundError` on any machine that has `~/.claude/agents` populated.

## Root cause

`tests/conftest.py:82-92` already solves this for the shared `session_engine` fixture with `monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")`, so synthetic agent names do not require matching files on disk.

`test_concurrency.py:34-42` defines its **own** `engine` fixture — it needs the `database=db` SQLite wiring the shared fixture lacks — and dropped that line. `AgentValidator._resolve_mode()` defaults to `strict` (`agent_validator.py:105`), `agent_register` calls `validate()` unconditionally before any DB work (`session_engine.py:2964`), and strict mode raises at `agent_validator.py:143`.

## Why it went unnoticed

The failure is environment-dependent **in the inverted direction**. `agent_validator.py:77-83` silently forces `mode="off"` when the agents root does not exist:

> `agents_root does not exist -- agent validation disabled`

So these tests pass on CI runners, fresh clones, and containers — precisely where they are validating nothing — and fail only on a developer machine with agents installed. The concurrency/idempotency behaviour these tests exist to verify had never actually been exercised with validation live.

## Fix

One line: restore the `monkeypatch.setenv` in the local fixture, matching the established pattern in `tests/conftest.py`.

## Blast radius

Exactly one file. Of the 18 test files constructing `SessionIntelligenceEngine`, only 3 call `agent_register`; the other two (`tests/unit/test_session_engine_agent_validation.py`, `tests/engine/test_agent_operations.py` via `tests/engine/conftest.py:31`) already set the env var.

## Verification

- `pytest tests/integration/test_concurrency.py -v` with **no** env override, on a machine where `~/.claude/agents` exists: **6 passed** (was 4 passed / 2 failed).
- `SESSION_INTELLIGENCE_AGENTS_DIR=/tmp/nonexistent` (CI simulation, strict still default): 6 passed.
- Full suite with `POSTGRES_DSN` pointed at a throwaway `session_intelligence_test` DB: **503 passed, 0 failed, 0 skipped**.

## Follow-ups (not in this PR)

Two design issues surfaced but are deliberately out of scope:

1. `AgentValidator()` is hardcoded at `session_engine.py:203` — the engine constructor takes `repository_path`/`use_filesystem`/`database` but no validator or mode, so tests can only steer it through process-global env vars instead of injecting a stub.
2. Validation **fails open**: if `~/.claude/agents` is ever missing in production, all agent-name validation becomes a silent no-op behind a single `logger.warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)