### PR TITLE
fix(engine): derive project_name for hook-bound sessions instead of _unbound_

### DIFF
--- a/scripts/migrations/backfill_unbound_session_project_names.py
+++ b/scripts/migrations/backfill_unbound_session_project_names.py
@@ -1,0 +1,343 @@
+"""Backfill sessions.project_name for rows stranded under the '_unbound_' sentinel.
+
+Re-derives project_name from each row's stored project_path using the shared
+core.project_naming.derive_project_name() helper (git remote origin basename ->
+git toplevel basename -> path basename -> UNBOUND). As of 2026-08-04, 5,797 of
+7,286 rows in the sessions table are stranded under '_unbound_'.
+
+Note: paths that no longer exist on disk fall back to basename derivation
+(derive_project_name never raises); this is expected and acceptable.
+
+Idempotent — only ever touches rows still matching
+    WHERE project_name = '_unbound_' AND project_path IS NOT NULL AND project_path <> ''
+so a rerun after a successful --apply naturally has nothing left to do for the
+rows it already fixed.
+
+Excluding untrustworthy paths:
+    Some stranded rows got their project_path from the server process's own
+    cwd rather than the caller's project (see session_engine.py's
+    `_create_session`, which defaults project_path to the server cwd). A
+    dry-run against production on 2026-08-04 found 5,767 of 5,835 candidate
+    rows all sharing ONE such path:
+    /home/memento/ClaudeCode/Servers/session-intelligence/development
+    (the session-intelligence server's own working directory). Backfilling
+    those would incorrectly stamp "session-intelligence" onto thousands of
+    sessions that actually belong to many different projects. The remaining
+    ~68 rows have genuine, distinct project paths and ARE safely recoverable.
+
+    Use --exclude-path (repeatable) to exclude specific paths from the
+    backfill entirely. Matching is an EXACT string match on project_path —
+    NOT a prefix or glob match — so each untrustworthy path must be listed
+    verbatim. Excluded rows are removed from consideration before --limit is
+    applied, and are reported separately in the summary so the totals
+    reconcile.
+
+    PYTHONPATH=src python scripts/migrations/backfill_unbound_session_project_names.py \
+        --exclude-path /home/memento/ClaudeCode/Servers/session-intelligence/development
+
+Safety:
+    - Default mode is --dry-run (report only, no writes).
+    - --apply requires --yes, or it refuses and exits non-zero.
+    - Rows whose re-derived name is still '_unbound_' are never written; they
+      are counted and reported as skipped.
+    - Updates run inside a transaction, batched (default 500 rows/batch), with
+      progress logged per batch.
+
+Usage (report only, safe to run anytime):
+    PYTHONPATH=src python scripts/migrations/backfill_unbound_session_project_names.py
+
+Usage (staged rollout, first 500 rows only):
+    PYTHONPATH=src python scripts/migrations/backfill_unbound_session_project_names.py \
+        --apply --yes --limit 500
+
+Usage (full apply):
+    PYTHONPATH=src python scripts/migrations/backfill_unbound_session_project_names.py \
+        --apply --yes
+
+Environment variables:
+    POSTGRES_DSN  PostgreSQL DSN (required unless --dsn is passed explicitly)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import urllib.parse
+
+from core.project_naming import UNBOUND, derive_project_name
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+
+
+def get_db_name(dsn: str) -> str:
+    """Extract the database name from a PostgreSQL DSN for operator confirmation."""
+    parsed = urllib.parse.urlparse(dsn)
+    return parsed.path.lstrip("/") or "(unspecified)"
+
+
+def print_summary(
+    derived_counts: dict[str, int],
+    examined: int,
+    would_change: int,
+    still_unbound: int,
+    skipped_empty_path: int,
+    skipped_excluded_path: int,
+) -> None:
+    """Print the derived_name -> row_count table plus overall totals."""
+    print()
+    print(f"{'derived_name':<50} {'row_count':>10}")
+    print("-" * 61)
+    for name, count in sorted(derived_counts.items(), key=lambda kv: kv[1], reverse=True):
+        print(f"{name:<50} {count:>10}")
+    print("-" * 61)
+    print(f"Rows examined:                              {examined}")
+    print(f"Rows that would change / did change:        {would_change}")
+    print(f"Rows skipped (derivation still {UNBOUND!r}):    {still_unbound}")
+    print(f"Rows skipped (empty/NULL project_path):     {skipped_empty_path}")
+    print(f"Rows skipped (--exclude-path):               {skipped_excluded_path}")
+    print()
+
+
+async def _execute_batch(conn, batch: list[tuple[str, str]]) -> int:
+    """Apply one batch of (project_path, derived_name) updates inside a transaction."""
+    updated = 0
+    async with conn.transaction():
+        for project_path, derived_name in batch:
+            result = await conn.execute(
+                """
+                UPDATE sessions
+                SET project_name = $1
+                WHERE project_name = $2
+                  AND project_path = $3
+                """,
+                derived_name,
+                UNBOUND,
+                project_path,
+            )
+            updated += int(result.split()[-1]) if result else 0
+    return updated
+
+
+async def apply_updates(
+    conn, path_updates: list[tuple[str, str, int]], batch_size: int = BATCH_SIZE
+) -> int:
+    """Apply updates grouped by distinct project_path, batched by ~batch_size rows.
+
+    path_updates: list of (project_path, derived_name, row_count) for paths whose
+    re-derived name is not UNBOUND.
+    """
+    total_updated = 0
+    total_paths = len(path_updates)
+    processed_paths = 0
+    batch: list[tuple[str, str]] = []
+    batch_rows = 0
+
+    for project_path, derived_name, row_count in path_updates:
+        batch.append((project_path, derived_name))
+        batch_rows += row_count
+        if batch_rows >= batch_size:
+            total_updated += await _execute_batch(conn, batch)
+            processed_paths += len(batch)
+            logger.info(
+                f"Progress: {processed_paths}/{total_paths} paths, "
+                f"{total_updated} rows updated so far"
+            )
+            batch = []
+            batch_rows = 0
+
+    if batch:
+        total_updated += await _execute_batch(conn, batch)
+        processed_paths += len(batch)
+        logger.info(
+            f"Progress: {processed_paths}/{total_paths} paths, "
+            f"{total_updated} rows updated so far"
+        )
+
+    return total_updated
+
+
+async def backfill(
+    dsn: str,
+    apply_changes: bool,
+    limit: int | None,
+    exclude_paths: list[str] | None = None,
+) -> None:
+    """Run the backfill (or dry-run report) against a PostgreSQL database.
+
+    exclude_paths: project_path values excluded from consideration via an
+    EXACT string match (not a prefix/glob match). Use for paths known to be
+    untrustworthy, e.g. a server process's own cwd rather than the caller's
+    project.
+    """
+    try:
+        import asyncpg
+    except ImportError:
+        logger.error("asyncpg is required for PostgreSQL. Install with: pip install asyncpg")
+        sys.exit(1)
+
+    exclude_paths = list(exclude_paths) if exclude_paths else []
+
+    db_name = get_db_name(dsn)
+    logger.info(f"Target database: {db_name}")
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        total_sessions = await conn.fetchval("SELECT COUNT(*) FROM sessions")
+        logger.info(f"Total rows in sessions table: {total_sessions}")
+
+        skipped_empty_path = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM sessions
+            WHERE project_name = $1
+              AND (project_path IS NULL OR project_path = '')
+            """,
+            UNBOUND,
+        )
+
+        skipped_excluded_path = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM sessions
+            WHERE project_name = $1
+              AND project_path IS NOT NULL
+              AND project_path <> ''
+              AND project_path = ANY($2::text[])
+            """,
+            UNBOUND,
+            exclude_paths,
+        )
+
+        rows = await conn.fetch(
+            """
+            SELECT project_path, COUNT(*) AS row_count
+            FROM (
+                SELECT project_path FROM sessions
+                WHERE project_name = $1
+                  AND project_path IS NOT NULL
+                  AND project_path <> ''
+                  AND project_path <> ALL($3::text[])
+                ORDER BY id
+                LIMIT $2::bigint
+            ) sub
+            GROUP BY project_path
+            ORDER BY row_count DESC
+            """,
+            UNBOUND,
+            limit,
+            exclude_paths,
+        )
+
+        examined = sum(row["row_count"] for row in rows)
+
+        # Derivation is per-distinct-path, not per-row: far fewer paths than rows.
+        to_update: list[tuple[str, str, int]] = []
+        still_unbound_count = 0
+        derived_counts: dict[str, int] = {}
+        for row in rows:
+            project_path = row["project_path"]
+            row_count = row["row_count"]
+            derived_name = derive_project_name(project_path)
+            derived_counts[derived_name] = derived_counts.get(derived_name, 0) + row_count
+            if derived_name == UNBOUND:
+                still_unbound_count += row_count
+            else:
+                to_update.append((project_path, derived_name, row_count))
+
+        would_change = sum(row_count for _, _, row_count in to_update)
+
+        print_summary(
+            derived_counts,
+            examined,
+            would_change,
+            still_unbound_count,
+            skipped_empty_path,
+            skipped_excluded_path,
+        )
+
+        if apply_changes:
+            updated = await apply_updates(conn, to_update)
+            logger.info(f"APPLY complete: {updated} rows updated.")
+        else:
+            logger.info(
+                "DRY RUN complete — no changes written. Re-run with --apply --yes to write."
+            )
+    finally:
+        await conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill sessions.project_name for rows stranded under the "
+            f"{UNBOUND!r} sentinel by re-deriving the name from project_path."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("POSTGRES_DSN"),
+        help="PostgreSQL DSN (default: POSTGRES_DSN env var)",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report only, never write (default mode)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the UPDATE. Requires --yes.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm --apply. Required alongside --apply.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of stranded rows processed (for a staged rollout)",
+    )
+    parser.add_argument(
+        "--exclude-path",
+        action="append",
+        default=None,
+        metavar="PATH",
+        dest="exclude_path",
+        help=(
+            "Exact project_path to exclude from the backfill (repeatable). "
+            "Use for paths that record the server's own cwd rather than the "
+            "caller's project. Matching is an EXACT string match, not a "
+            "prefix or glob match."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not args.dsn:
+        parser.error("--dsn is required (or set the POSTGRES_DSN environment variable)")
+    if args.apply and not args.yes:
+        parser.error("--apply requires --yes to confirm you intend to write to the database")
+
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(
+        backfill(
+            args.dsn,
+            apply_changes=args.apply,
+            limit=args.limit,
+            exclude_paths=args.exclude_path,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/project_naming.py
+++ b/src/core/project_naming.py
@@ -1,0 +1,176 @@
+"""Derive a stable ``project_name`` from a filesystem path.
+
+Historically, sessions created without an explicit ``project_name`` were filed
+under the ``_unbound_`` sentinel. Because ``session_recall`` and
+``session_search`` are project-scoped, those sessions became invisible: as of
+2026-08-04 that was 5,797 of 7,286 rows (79.6%) in the production database.
+
+Both creation sites that produced the sentinel already had a ``project_path``
+in hand, so the name is recoverable. This module does the recovery.
+
+Derivation order (first non-empty wins):
+
+1. ``git remote get-url origin`` -> repository basename
+2. ``git rev-parse --show-toplevel`` -> directory basename
+3. ``Path(project_path).name``
+4. ``_unbound_`` (only when the path is unusable and git tells us nothing)
+
+Step 1 leads deliberately. The names already in the database
+(``numba-feedstock``, ``hb-event-bus``, ``staged-recipes``,
+``session-intelligence``) are *repository* names, and a checkout is frequently
+rooted in a directory that describes its role rather than the project -- for
+this repo, ``.../session-intelligence/development``, whose basename is
+``development``. Steps 2 and 3 are last-resort fallbacks for repositories with
+no remote; they are intentionally literal rather than trying to guess which
+directory names are role descriptors.
+
+Every git call is best-effort: failures, timeouts, and a missing ``git``
+binary all fall through to the next step rather than propagating.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Sentinel used when no name can be derived. Rows carrying this value are
+#: invisible to project-scoped recall, which is the bug this module exists to
+#: stop reproducing.
+UNBOUND = "_unbound_"
+
+#: Git is called on the session-creation hot path, so keep it short. A stalled
+#: git call must never become a stalled session write.
+_GIT_TIMEOUT_S = 2.0
+
+
+def _run_git(args: list[str], cwd: Path) -> str | None:
+    """Run a git command, returning stripped stdout or None on any failure."""
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        # Missing binary, timeout, permission error -- all non-fatal.
+        logger.debug("git %s failed in %s: %s", " ".join(args), cwd, exc)
+        return None
+
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _sanitize(name: str | None) -> str | None:
+    """Reject names that would be useless or misleading as a project scope."""
+    if not name:
+        return None
+    name = name.strip().strip("/")
+    if not name or name in {".", ".."} or "/" in name or "\\" in name:
+        return None
+    return name
+
+
+def repo_name_from_remote_url(url: str) -> str | None:
+    """Extract the repository basename from any git remote URL form.
+
+    Handles the three shapes git actually emits::
+
+        https://github.com/Claire-s-Monster/session-intelligence.git
+        git@github.com:Claire-s-Monster/session-intelligence.git
+        /srv/git/session-intelligence.git
+
+    all of which yield ``session-intelligence``.
+    """
+    url = (url or "").strip()
+    if not url:
+        return None
+
+    # Drop any query string or fragment before looking at the tail.
+    url = url.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+
+    tail = url.rsplit("/", 1)[-1]
+    # scp-like remotes with no path component, e.g. "git@host:repo.git".
+    if "/" not in url and ":" in tail:
+        tail = tail.rsplit(":", 1)[-1]
+
+    if tail.endswith(".git"):
+        tail = tail[: -len(".git")]
+
+    return _sanitize(tail)
+
+
+@lru_cache(maxsize=256)
+def _derive_cached(resolved: str) -> str:
+    """Cached derivation keyed on an already-resolved directory path.
+
+    Cached because session creation can happen many times against the same
+    working directory and each miss costs up to two subprocess spawns. A
+    process-lifetime cache is acceptable: a repository's remote changing
+    mid-process is not a case worth paying for on every write.
+    """
+    path = Path(resolved)
+
+    remote_url = _run_git(["remote", "get-url", "origin"], path)
+    if remote_url:
+        name = repo_name_from_remote_url(remote_url)
+        if name:
+            return name
+
+    toplevel = _run_git(["rev-parse", "--show-toplevel"], path)
+    if toplevel:
+        name = _sanitize(Path(toplevel).name)
+        if name:
+            return name
+
+    name = _sanitize(path.name)
+    if name:
+        return name
+
+    return UNBOUND
+
+
+def derive_project_name(project_path: str | Path | None) -> str:
+    """Best-effort project name for ``project_path``.
+
+    Never raises and never returns an empty string; callers can use the result
+    directly as a ``project_name``. Returns :data:`UNBOUND` only when the path
+    is missing or yields nothing usable.
+    """
+    if not project_path:
+        return UNBOUND
+
+    try:
+        path = Path(project_path).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        logger.debug("could not resolve project_path %r: %s", project_path, exc)
+        return UNBOUND
+
+    # git needs an existing directory to run in. Probe the path itself, or its
+    # immediate parent when the path names a file.
+    #
+    # Deliberately do NOT walk further up. The backfill migration feeds this
+    # function thousands of *historical* project_path values, many pointing at
+    # directories that have since been deleted. An arbitrarily distant ancestor
+    # belongs to a different project: walking up from a stale ~/work/gone/repo
+    # would reach the home directory and derive "memento", confidently
+    # mislabelling those rows instead of leaving them honestly unbound. One
+    # level covers a path that names a file; past that, fall back to the path's
+    # own basename, which is what the row itself claims.
+    probe = path if path.is_dir() else path.parent
+
+    if not probe.is_dir():
+        return _sanitize(path.name) or UNBOUND
+
+    try:
+        return _derive_cached(str(probe))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("project name derivation failed for %s: %s", probe, exc)
+        return _sanitize(path.name) or UNBOUND

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from core.agent_validator import AgentValidator
+from core.project_naming import derive_project_name
 from models.session_models import (
     Agent,
     AgentDecision,
@@ -405,6 +406,14 @@ class SessionIntelligenceEngine:
 
         # Create new session if none exists or is valid
         debug_logger.info("Creating new session")
+        # Deliberately still "_unbound_". Unlike the hook-bound site below,
+        # this path has no caller-supplied working directory -- it can only
+        # use the *server process* cwd, which under the systemd HTTP
+        # deployment is pinned to the session-intelligence checkout and would
+        # stamp that name onto every caller's session. Callers reaching here
+        # via allow_unbound=True have also explicitly opted into the legacy
+        # sentinel; see tests/test_session_recall_project_binding.py::
+        # test_log_without_create_with_allow_unbound_uses_sentinel.
         result = self._create_session(
             mode="auto",
             project_name="_unbound_",
@@ -869,13 +878,14 @@ class SessionIntelligenceEngine:
                 "binding a session-intelligence session to it (likely a "
                 "hook-supplied Claude Code native session id)"
             )
+            hook_cwd = step_data.get(
+                "working_directory", str(Path.cwd().resolve())
+            )
             create_result = self._create_session(
                 mode="auto",
-                project_name="_unbound_",
+                project_name=derive_project_name(hook_cwd),
                 metadata={
-                    "project_path": step_data.get(
-                        "working_directory", str(Path.cwd().resolve())
-                    ),
+                    "project_path": hook_cwd,
                     "tags": ["hook-bound", "claude-native-session"],
                 },
                 session_name=None,

--- a/tests/unit/test_project_naming.py
+++ b/tests/unit/test_project_naming.py
@@ -1,0 +1,177 @@
+"""Unit tests for core.project_naming.
+
+Covers the pure helpers (repo_name_from_remote_url, derive_project_name) that
+recover a usable project_name from a filesystem path, replacing the
+"_unbound_" sentinel that made 79.6% of production session rows invisible to
+project-scoped recall.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+import core.project_naming as project_naming
+from core.project_naming import (
+    UNBOUND,
+    _derive_cached,
+    derive_project_name,
+    repo_name_from_remote_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_derive_cache():
+    """Prevent lru_cache leakage between tests.
+
+    _derive_cached is keyed on a resolved directory path; without clearing it
+    a result cached by one test (e.g. a monkeypatched _run_git) would silently
+    satisfy a later test against the same path, making pass/fail depend on
+    test order.
+    """
+    _derive_cached.cache_clear()
+    yield
+    _derive_cached.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# repo_name_from_remote_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "https://github.com/Claire-s-Monster/session-intelligence.git",
+            "session-intelligence",
+        ),
+        (
+            "https://github.com/Claire-s-Monster/session-intelligence",
+            "session-intelligence",
+        ),
+        (
+            "git@github.com:Claire-s-Monster/session-intelligence.git",
+            "session-intelligence",
+        ),
+        (
+            "ssh://git@github.com/Claire-s-Monster/session-intelligence.git",
+            "session-intelligence",
+        ),
+        (
+            "/srv/git/session-intelligence.git",
+            "session-intelligence",
+        ),
+        (
+            "https://github.com/Claire-s-Monster/session-intelligence.git/",
+            "session-intelligence",
+        ),
+        ("", None),
+        ("   ", None),
+    ],
+)
+def test_repo_name_from_remote_url(url: str, expected: str | None) -> None:
+    assert repo_name_from_remote_url(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# derive_project_name - derivation order, with _run_git monkeypatched
+# ---------------------------------------------------------------------------
+
+
+def test_derive_project_name_remote_wins_and_toplevel_not_relied_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When a remote URL is present, its repo name wins and the toplevel
+    git call is never made (short-circuit)."""
+    calls: list[list[str]] = []
+
+    def fake_run_git(args: list[str], cwd: Path) -> str | None:
+        calls.append(args)
+        if args[0] == "remote":
+            return "https://github.com/Claire-s-Monster/session-intelligence.git"
+        raise AssertionError(
+            f"toplevel git call {args!r} should not have been made when "
+            "a remote URL already resolved a name"
+        )
+
+    monkeypatch.setattr(project_naming, "_run_git", fake_run_git)
+
+    result = derive_project_name(str(tmp_path))
+
+    assert result == "session-intelligence"
+    assert len(calls) == 1
+    assert calls[0][0] == "remote"
+
+
+def test_derive_project_name_falls_back_to_toplevel_when_remote_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No remote origin -> falls back to `git rev-parse --show-toplevel`
+    basename."""
+
+    def fake_run_git(args: list[str], cwd: Path) -> str | None:
+        if args[0] == "remote":
+            return None
+        if args[0] == "rev-parse":
+            return "/some/checkout/root/my-toplevel-repo"
+        raise AssertionError(f"unexpected git call: {args!r}")
+
+    monkeypatch.setattr(project_naming, "_run_git", fake_run_git)
+
+    result = derive_project_name(str(tmp_path))
+
+    assert result == "my-toplevel-repo"
+
+
+def test_derive_project_name_falls_back_to_path_basename_when_git_yields_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both git calls fail -> falls back to the path's own basename."""
+    monkeypatch.setattr(project_naming, "_run_git", lambda args, cwd: None)
+
+    result = derive_project_name(str(tmp_path))
+
+    assert result == tmp_path.name
+
+
+@pytest.mark.parametrize("bad_input", [None, ""])
+def test_derive_project_name_none_or_empty_input_is_unbound(
+    bad_input: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_run_git(args: list[str], cwd: Path) -> str | None:
+        raise AssertionError("git must not be invoked for a falsy project_path")
+
+    monkeypatch.setattr(project_naming, "_run_git", fail_run_git)
+
+    assert derive_project_name(bad_input) == UNBOUND
+
+
+def test_derive_project_name_nonexistent_path_walks_up_to_existing_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path that doesn't exist on disk still derives a name by walking up
+    to the nearest existing parent directory, rather than falling straight
+    to UNBOUND."""
+    monkeypatch.setattr(project_naming, "_run_git", lambda args, cwd: None)
+
+    missing = tmp_path / "does" / "not" / "exist"
+
+    result = derive_project_name(str(missing))
+
+    assert result != UNBOUND
+
+
+# ---------------------------------------------------------------------------
+# Integration: real git, real repo (no monkeypatching)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not shutil.which("git"), reason="git binary not available")
+def test_derive_project_name_real_repo_resolves_to_session_intelligence() -> None:
+    result = derive_project_name(
+        "/home/memento/ClaudeCode/Servers/session-intelligence/development"
+    )
+    assert result == "session-intelligence"

--- a/tests/unit/test_project_naming.py
+++ b/tests/unit/test_project_naming.py
@@ -149,18 +149,25 @@ def test_derive_project_name_none_or_empty_input_is_unbound(
     assert derive_project_name(bad_input) == UNBOUND
 
 
-def test_derive_project_name_nonexistent_path_walks_up_to_existing_parent(
+def test_derive_project_name_nonexistent_path_falls_back_to_own_basename(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A path that doesn't exist on disk still derives a name by walking up
-    to the nearest existing parent directory, rather than falling straight
-    to UNBOUND."""
+    """A path that doesn't exist on disk derives a name from its own
+    basename rather than walking up an unbounded chain of parents.
+
+    The walk-up is bounded to at most one level (the path itself, or its
+    immediate parent if the path names a file) because the backfill
+    migration feeds this function thousands of historical paths whose
+    directories no longer exist. An unbounded walk-up would keep climbing
+    until it reached the home directory and mislabel all of those rows
+    under the same ancestor name."""
     monkeypatch.setattr(project_naming, "_run_git", lambda args, cwd: None)
 
     missing = tmp_path / "does" / "not" / "exist"
 
     result = derive_project_name(str(missing))
 
+    assert result == "exist"
     assert result != UNBOUND
 
 
@@ -170,8 +177,18 @@ def test_derive_project_name_nonexistent_path_walks_up_to_existing_parent(
 
 
 @pytest.mark.skipif(not shutil.which("git"), reason="git binary not available")
+@pytest.mark.skipif(
+    not (Path(__file__).resolve().parents[2] / ".git").exists(),
+    reason="not a git checkout",
+)
 def test_derive_project_name_real_repo_resolves_to_session_intelligence() -> None:
-    result = derive_project_name(
-        "/home/memento/ClaudeCode/Servers/session-intelligence/development"
-    )
+    """Resolve the repo root relative to this test file's own location
+    (tests/unit/<file> -> repo root) rather than hardcoding a developer
+    machine's absolute path, so this test is portable across local
+    machines and CI runners alike. On CI, actions/checkout leaves an
+    'origin' remote pointing at the repo, and git-remote is the first
+    step of the derivation chain, so the assertion holds in both
+    environments."""
+    repo_root = Path(__file__).resolve().parents[2]
+    result = derive_project_name(str(repo_root))
     assert result == "session-intelligence"

--- a/tests/unit/test_session_project_binding_regression.py
+++ b/tests/unit/test_session_project_binding_regression.py
@@ -1,0 +1,141 @@
+"""Regression test for the "_unbound_" session/project binding bug.
+
+Both hook-driven session auto-create paths in SessionIntelligenceEngine used
+to file sessions under project_name="_unbound_" whenever they had to invent
+a session on the fly (no explicit project_name/session_id resolution
+context). Because session_recall / session_search are project-scoped, those
+sessions became permanently invisible: as of 2026-08-04 that was 5,797 of
+7,286 rows (79.6%) in the production database.
+
+Only the hook-bound site (session_engine.py ~line 886, caller-supplied
+working_directory via step_data) now derives a real project_name via
+core.project_naming.derive_project_name(). The legacy
+_get_or_create_current_session_id auto path (~line 408) deliberately
+retains the "_unbound_" sentinel: it only has the server process's own cwd
+available -- which under the systemd HTTP deployment is pinned to the
+session-intelligence checkout, not the caller's project -- and allow_unbound
+callers depend on this sentinel being stable
+(see tests/test_session_recall_project_binding.py::
+test_log_without_create_with_allow_unbound_uses_sentinel).
+
+This module exercises both sites through their real public entry point
+(session_track_execution), not the private _create_session helper directly,
+so it actually reproduces the regression and pins the intended fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import core.project_naming as project_naming
+from core.project_naming import UNBOUND
+
+
+@pytest.fixture(autouse=True)
+def _clear_derive_cache():
+    """See tests/unit/test_project_naming.py for why this is required:
+    _derive_cached is a process-lifetime lru_cache keyed on resolved path,
+    and leaks results across tests without this."""
+    project_naming._derive_cached.cache_clear()
+    yield
+    project_naming._derive_cached.cache_clear()
+
+
+@pytest.fixture
+def fake_remote_git(monkeypatch: pytest.MonkeyPatch):
+    """Monkeypatch _run_git so derivation is hermetic: it returns a known
+    remote URL instead of depending on the host's actual git state."""
+
+    def fake_run_git(args: list[str], cwd: Path) -> str | None:
+        if args[0] == "remote":
+            return "https://github.com/Claire-s-Monster/session-intelligence.git"
+        return None
+
+    monkeypatch.setattr(project_naming, "_run_git", fake_run_git)
+    return fake_run_git
+
+
+# ---------------------------------------------------------------------------
+# Site 1: hook-bound auto-create inside the execution-tracking path
+# (session_engine.py ~line 872) -- produced 5,797/7,286 _unbound_ rows.
+# ---------------------------------------------------------------------------
+
+
+def test_hook_bound_execution_tracking_does_not_produce_unbound_session(
+    session_engine, tmp_path: Path, fake_remote_git
+) -> None:
+    """Drives the real regressed path: session_track_execution() called with
+    a session_id the engine has never seen (as a hook supplying Claude
+    Code's native subagent session UUID would), forcing the hook-bound
+    auto-create branch in _track_execution_sync.
+    """
+    working_dir = tmp_path / "hook-workdir"
+    working_dir.mkdir()
+
+    result = session_engine.session_track_execution(
+        session_id="claude-native-session-abc123",
+        agent_name="test-agent",
+        step_data={"working_directory": str(working_dir)},
+    )
+
+    assert result.status == "success", f"unexpected status: {result.status}"
+    assert result.session_id in session_engine.session_cache
+
+    session = session_engine.session_cache[result.session_id]
+
+    assert session.project_name != UNBOUND, (
+        "REGRESSION: hook-bound auto-create must not file the session "
+        "under the '_unbound_' sentinel -- this is the production bug "
+        "that made 5,797/7,286 session rows invisible to project-scoped "
+        "session_recall"
+    )
+    assert session.project_name == "session-intelligence"
+    assert session.project_path == str(working_dir), (
+        "project_path must stay self-consistent with the derived "
+        "project_name's source directory"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Site 2 (legacy): _get_or_create_current_session_id auto path
+# (session_engine.py ~line 408), driven indirectly through
+# session_track_execution(session_id=None). This path deliberately keeps the
+# "_unbound_" sentinel -- see module docstring.
+# ---------------------------------------------------------------------------
+
+
+def test_auto_current_session_id_still_uses_unbound_sentinel(
+    session_engine, tmp_path: Path, fake_remote_git, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No session_id supplied and no existing current session -> engine
+    auto-creates one via _get_or_create_current_session_id. Even though
+    fake_remote_git makes derivation available and would return a real name
+    if this path were wired to use it, it must still stamp '_unbound_':
+    this path only has the server process's own cwd, not a caller-supplied
+    working directory, and allow_unbound=True callers rely on this sentinel
+    being stable."""
+    working_dir = tmp_path / "auto-workdir"
+    working_dir.mkdir()
+    monkeypatch.chdir(working_dir)
+
+    result = session_engine.session_track_execution(
+        session_id=None,
+        agent_name="test-agent",
+        step_data={},
+    )
+
+    assert result.status == "success", f"unexpected status: {result.status}"
+    assert result.session_id in session_engine.session_cache
+
+    session = session_engine.session_cache[result.session_id]
+
+    assert session.project_name == UNBOUND, (
+        "_get_or_create_current_session_id intentionally preserves the "
+        "'_unbound_' sentinel: it only has the server-process cwd "
+        "available (not a caller-supplied working directory), and "
+        "allow_unbound=True callers depend on this sentinel remaining "
+        "stable -- see test_session_recall_project_binding.py::"
+        "test_log_without_create_with_allow_unbound_uses_sentinel"
+    )

--- a/tests/unit/test_session_project_binding_regression.py
+++ b/tests/unit/test_session_project_binding_regression.py
@@ -92,10 +92,9 @@ def test_hook_bound_execution_tracking_does_not_produce_unbound_session(
         "session_recall"
     )
     assert session.project_name == "session-intelligence"
-    assert session.project_path == str(working_dir), (
-        "project_path must stay self-consistent with the derived "
-        "project_name's source directory"
-    )
+    assert session.project_path == str(
+        working_dir
+    ), "project_path must stay consistent with the derived name's source dir"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Sessions auto-created by the Claude Code hook were filed under the `_unbound_` sentinel. `session_recall` and `session_search` are project-scoped, so those sessions were permanently invisible.

## Fix

The hook-bound auto-create site already had the caller's working directory in hand (`step_data["working_directory"]`), so the name was recoverable. New `core.project_naming.derive_project_name()` resolves:

1. `git remote get-url origin` → repository basename
2. `git rev-parse --show-toplevel` → directory basename
3. `Path(project_path).name`
4. `_unbound_`

Every git call is best-effort — missing binary, non-zero exit, or timeout falls through rather than propagating. Results are `lru_cache`d per resolved path, since session creation repeatedly hits the same directory.

### Why git-remote-first

The names already in the database (`numba-feedstock`, `hb-event-bus`, `staged-recipes`) are *repository* names, and checkouts are often rooted in a directory naming the checkout's **role** rather than the project — this repo lives at `.../session-intelligence/development`, whose basename is `development`.

Measured against real data, the remote also **normalises variants**: `zig-feedstock-2` and `zig-feedstock-0.17` both resolve to `zig-feedstock`, and `ocaml-feedstock-5.4.0-altc` → `ocaml-feedstock`. A basename strategy would have produced three separate wrong buckets.

## Applied at one site, deliberately

| Site | Behaviour |
|---|---|
| `session_engine.py:872` — hook-bound, caller-supplied `working_directory` | **Derives.** Source of the bulk of `_unbound_` rows. |
| `session_engine.py:408` — `_get_or_create_current_session_id` | **Keeps the sentinel.** |

The legacy path can see nothing but the **server process** cwd, which under the systemd HTTP deployment is pinned to this checkout — it would stamp `session-intelligence` onto every caller's session. Callers reaching it via `allow_unbound=True` have also explicitly opted into the legacy sentinel, a contract pinned by `test_log_without_create_with_allow_unbound_uses_sentinel`.

That test also matters for a second, quieter reason: its teardown is `_cleanup(db, ["_unbound_"])`, which **deletes by project name**. Renaming the row there would silently leak fixture rows into whatever database the suite runs against, including CI's `ci_test`. An earlier revision of this branch did exactly that; the suite caught it.

## Backfill migration

`scripts/migrations/backfill_unbound_session_project_names.py`, mirroring the conventions of the existing `backfill_project_learnings_project_name.py`.

**A dry-run against production reframed this entirely.** Of 5,835 candidate rows, **5,767 share a single `project_path`** — this server's own cwd, recorded because `_create_session` defaults `project_path` to `Path.cwd()` (`session_engine.py:572`). That column carries no information about the caller's project, so deriving from it would convert honestly-unbound rows into confidently-wrong ones, irreversibly and at scale.

Hence `--exclude-path` (exact match, applied in SQL so the examined-row count reflects it). With the server cwd excluded:

```
zig-feedstock 17 | ocaml-feedstock 11 | hummingbot 10 | numba-feedstock 9
roth_planner 6 | Config 4 | shell-runner 3 | package-incubator 2 | (6 more)

Rows examined: 68 | Would change: 68
Skipped (still '_unbound_'): 0 | Skipped (--exclude-path): 5769
```

So the genuinely recoverable population is **~68 rows, not ~5,797**.

Safety: dry-run is the default; `--apply` additionally requires `--yes`; the target database name and total row count are printed before anything happens; the `UPDATE` re-checks `project_name = '_unbound_'` in its own `WHERE`; rows still deriving to the sentinel are never written. **The script has not been applied to any database.**

## Not addressed here

The underlying defect behind those 5,767 rows — sessions recording the server's cwd as their `project_path` — belongs to the hook/caller contract, not to name derivation. It is still accruing (the excluded count rose 5,767 → 5,769 within minutes of observation) and deserves its own issue.

## Tests

`tests/unit/test_project_naming.py` (15) — parametrised remote-URL forms (https, scp-like, ssh://, local path, no-`.git`, trailing slash), derivation order with `_run_git` monkeypatched, non-existent paths, and one un-mocked integration check. An autouse fixture clears the `lru_cache` between tests, without which results leak and outcomes become order-dependent.

`tests/unit/test_session_project_binding_regression.py` (2) — drives the real regressed path via the public `session_track_execution()`, not `_create_session` directly. Asserts the hook-bound site no longer yields the sentinel and that `project_path` stays consistent with the derived name; asserts the legacy path still *does* yield it, with the git fake applied so the assertion is meaningful rather than vacuous.

**Full suite: 520 passed, 0 failed** (`POSTGRES_DSN` pointed at a throwaway database), rebased onto `development` post-#47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)