### PR TITLE
fix: stop recording the server's cwd as project_path; anchor notes migration to UTC

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -79,6 +79,13 @@ debug_handler.setFormatter(
 debug_logger.addHandler(debug_handler)
 debug_logger.setLevel(logging.INFO)
 
+# Sentinel for "the caller did not tell us where they were working".
+# Never fall back to the server's own cwd: this process runs from the
+# systemd/pixi launch dir, so recording it silently misattributes the row
+# to wherever the daemon lives rather than to the caller's project.
+# Parallels the existing "_unbound_" sentinel used for project_name.
+UNKNOWN_PROJECT_PATH = "_unknown_"
+
 
 def safe_parse_datetime(value: Any) -> datetime | None:
     """Safely parse datetime from various input types.
@@ -578,7 +585,7 @@ class SessionIntelligenceEngine:
             started=datetime.now(UTC),
             mode=mode,
             project_name=project_name or "unknown",
-            project_path=metadata.get("project_path", str(Path.cwd())),
+            project_path=metadata.get("project_path") or UNKNOWN_PROJECT_PATH,
             session_name=session_name,
             metadata=session_metadata,
             health_status=HealthStatus(),
@@ -2736,11 +2743,11 @@ class SessionIntelligenceEngine:
             resolved_ctx.project_name if resolved_ctx else None
         )
 
-        # project_path: caller-supplied wins, then resolved session, then cwd fallback.
+        # project_path: caller-supplied wins, then resolved session, then the _unknown_ sentinel.
         effective_project = (
             project_path
             or (resolved_ctx.project_path if resolved_ctx else None)
-            or str(self.claude_sessions_path.parent)
+            or UNKNOWN_PROJECT_PATH
         )
 
         source_session = resolved_session_id

--- a/src/persistence/migration.py
+++ b/src/persistence/migration.py
@@ -23,7 +23,7 @@ import argparse
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -156,8 +156,12 @@ class MigrationManager:
         # Get notes for recent dates
         from datetime import timedelta
 
+        # Anchor the scan to UTC: note.date is derived from datetime.now(UTC).
+        # Using naive local time here meant that after local/UTC date rollover
+        # the newest notes were dated "ahead" of the scan's starting point and,
+        # because the scan only walks backward, were silently never migrated.
         for days_ago in range(365):  # Last year
-            date = (datetime.now() - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+            date = (datetime.now(UTC) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
             notes = await self.source.query_notes_by_date(date, limit=1000)
 
             for note in notes:

--- a/tests/engine/test_decision_learning.py
+++ b/tests/engine/test_decision_learning.py
@@ -14,7 +14,7 @@ asyncio_mode = "auto" (from pyproject.toml) — no @pytest.mark.asyncio needed.
 
 import pytest
 
-from core.session_engine import SessionIntelligenceEngine
+from core.session_engine import SessionIntelligenceEngine, UNKNOWN_PROJECT_PATH
 from models.session_models import DecisionResult, LearningResult
 
 
@@ -239,12 +239,11 @@ async def test_query_learnings_by_category(engine):
         allow_unbound=True,
     )
 
-    project_path = str(engine.claude_sessions_path.parent)
     error_fix_rows = await engine.database.query_project_learnings(
-        project_path=project_path, category="error_fix"
+        project_path=UNKNOWN_PROJECT_PATH, category="error_fix"
     )
     pattern_rows = await engine.database.query_project_learnings(
-        project_path=project_path, category="pattern"
+        project_path=UNKNOWN_PROJECT_PATH, category="pattern"
     )
 
     assert any("UTC timestamps" in r["learning_content"] for r in error_fix_rows)
@@ -266,8 +265,7 @@ async def test_update_learning_usage(engine):
     update = await engine.database.update_learning_usage(learning_id, success=True)
     assert update["updated"] is True
 
-    project_path = str(engine.claude_sessions_path.parent)
-    rows = await engine.database.query_project_learnings(project_path=project_path)
+    rows = await engine.database.query_project_learnings(project_path=UNKNOWN_PROJECT_PATH)
     matching = [r for r in rows if r["id"] == learning_id]
     assert matching
     # success_count was 1 on insert, now incremented to 2

--- a/tests/regression/test_async_await_bugs.py
+++ b/tests/regression/test_async_await_bugs.py
@@ -9,7 +9,7 @@ import inspect
 
 import pytest
 
-from core.session_engine import SessionIntelligenceEngine
+from core.session_engine import SessionIntelligenceEngine, UNKNOWN_PROJECT_PATH
 from persistence.sqlite import SQLiteBackend
 
 
@@ -50,9 +50,8 @@ class TestAsyncAwaitBugs:
             allow_unbound=True,
         )
 
-        project_path = str(engine.claude_sessions_path.parent)
         learnings = await engine.database.query_project_learnings(
-            project_path=project_path
+            project_path=UNKNOWN_PROJECT_PATH
         )
         assert len(learnings) >= 1
 

--- a/tests/unit/test_project_path_sentinel.py
+++ b/tests/unit/test_project_path_sentinel.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for the "_unknown_" project_path sentinel.
+
+Verifies that when no project_path is supplied (directly or via a
+resolvable session context), the engine records the explicit
+UNKNOWN_PROJECT_PATH sentinel rather than silently falling back to the
+server process's own cwd.
+
+Uses an in-memory SQLite backend so all tests are fully isolated from
+real filesystem state and PostgreSQL.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core.session_engine import UNKNOWN_PROJECT_PATH, SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory SQLite database, initialized and cleaned up per test."""
+    backend = SQLiteBackend(db_path=":memory:")
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+def engine(db, monkeypatch: pytest.MonkeyPatch) -> SessionIntelligenceEngine:
+    """Engine wired to in-memory SQLite, no filesystem."""
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", "/tmp/nonexistent-agents")
+    return SessionIntelligenceEngine(
+        repository_path=None,
+        use_filesystem=False,
+        database=db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSessionProjectPathSentinel:
+    def test_create_session_empty_metadata_uses_sentinel(self, engine):
+        """With no project_path in metadata, the sentinel is used, not cwd."""
+        result = engine._create_session(
+            mode="local",
+            project_name="proj-sentinel-empty",
+            metadata={},
+        )
+        assert result.status == "success"
+        assert result.session_data.project_path == UNKNOWN_PROJECT_PATH
+        assert result.session_data.project_path != str(Path.cwd())
+
+    def test_create_session_explicit_project_path_preserved(self, engine):
+        """An explicitly-supplied project_path is preserved verbatim."""
+        result = engine._create_session(
+            mode="local",
+            project_name="proj-sentinel-explicit",
+            metadata={"project_path": "/tmp/some/caller/path"},
+        )
+        assert result.status == "success"
+        assert result.session_data.project_path == "/tmp/some/caller/path"
+
+    def test_create_session_none_project_path_uses_sentinel(self, engine):
+        """An explicitly-passed None must also fall through to the sentinel."""
+        result = engine._create_session(
+            mode="local",
+            project_name="proj-sentinel-none",
+            metadata={"project_path": None},
+        )
+        assert result.status == "success"
+        assert result.session_data.project_path == UNKNOWN_PROJECT_PATH
+
+
+class TestSessionLogLearningProjectPathSentinel:
+    async def test_session_log_learning_unresolvable_context_uses_sentinel(
+        self, engine, db
+    ):
+        """No project_path and no resolvable session context -> sentinel stored."""
+        result = await engine.session_log_learning(
+            category="pattern",
+            learning_content="some learning content",
+            allow_unbound=True,
+        )
+        assert result.learning.project_path == UNKNOWN_PROJECT_PATH
+        assert result.learning.project_path != str(Path.cwd())


### PR DESCRIPTION
Two independent production defects, one commit each.

## 1. `8740411e` — server cwd recorded as the caller's `project_path`

`_create_session` defaulted `project_path` to `str(Path.cwd())`, which is the **systemd/pixi launch directory**, not the caller's project. Any session created without a caller-supplied working directory was attributed to wherever the daemon runs.

`_resolve_session_context` amplified it by calling `_create_session(metadata={})` with an empty literal, so the fallback fired on **every** first-time `project_name`-only call. `session_log_learning` had a second, independent fallback to `str(self.claude_sessions_path.parent)` that bypassed `_create_session` entirely.

Both now use a new `UNKNOWN_PROJECT_PATH` (`"_unknown_"`) sentinel, paralleling the existing `"_unbound_"` sentinel for `project_name`.

Subtlety worth reviewing: the change is `metadata.get(key) or SENTINEL`, **not** `metadata.get(key, default)`. A `.get` default only fires when the key is *absent*, so an explicitly-passed `None` would have stored `None`. There is a dedicated test for that case.

**Design decision:** `allow_unbound` governs `project_name` only. `project_path` always uses the sentinel when the caller supplies none — chosen over preserving a legacy path fallback, so the defect dies on every code path rather than leaving a deprecated escape hatch that still writes misleading rows.

Three existing tests looked learnings up by the old server-derived path and now use the sentinel. **No assertions were weakened.**

### Scope limit (please don't over-read this)
This stops the server **fabricating** a path. It does **not** repair rows already written, and it does not by itself prove production accrual has stopped — confirming that needs a live DB query after the server restarts.

## 2. `8a292613` — notes silently dropped by the migration date scan

`_migrate_notes` is the only entity migrated by a 365-day **backward** calendar scan; sessions, decisions and metrics use direct queries. It built date strings from `datetime.now()` (naive local) while a note's stored `date` derives from `datetime.now(UTC)`.

West of UTC, once UTC rolls to the next date the newest notes are dated *ahead* of the scan's starting point — and the scan only walks backward, so they match nothing. `migrate_all` reports `notes: 0` while every other entity succeeds.

This looked like a stable pre-existing failure but is a **time-of-day flake**: the same suite was green at 19:56 local and failed at 21:00+ local (past 00:00 UTC) on identical code. It is **real data loss**, so the `rm["notes"] >= 1` assertion was correctly catching it.

The file's other `datetime.now()` calls were audited and deliberately left: two are self-consistent elapsed-time deltas, two are display-only (`exported_at`, a filename timestamp).

### Known follow-up (deliberately not in this PR)
The 365-day backward scan is still fragile — notes older than a year remain invisible to `migrate_all`, and notes are the only entity migrated this way. A proper fix needs a session-scoped or full-scan note reader, which does not exist on the backend interface today (`base.py` declares only `save_note` and `query_notes_by_date`), so it would mean changing `base.py`, `sqlite.py` and `postgresql.py`. Worth its own issue.

## Verification

- **524 passed, 0 failed** (`POSTGRES_DSN=... pytest tests/ -q`)
- New `tests/unit/test_project_path_sentinel.py` — 4 tests, including the explicit-`None` case
- Ruff: **zero new errors**, verified by linting the pre-change version of the modified test file from git and confirming an identical error set before and after
- Both commits GPG-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)