### PR TITLE
fix(engine): derive project_name from a caller-supplied project_path instead of rejecting the write

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from core.agent_validator import AgentValidator
-from core.project_naming import derive_project_name
+from core.project_naming import UNBOUND, derive_project_name
 from models.session_models import (
     Agent,
     AgentDecision,
@@ -2707,6 +2707,31 @@ class SessionIntelligenceEngine:
         # check whether it actually exists in the DB and null it out if not.
         resolved_ctx: ResolvedSessionContext | None = None
         resolved_session_id: str | None = None
+
+        # No explicit session identifier and not opting into the legacy
+        # unbound fallback: try to derive a project_name from project_path
+        # before giving up. This is safe here in a way it is NOT for the
+        # legacy _get_or_create_current_session_id path (which PR #48
+        # deliberately left deriving from the SERVER's own cwd, since that
+        # path has no other data to go on) because project_path is data the
+        # CALLER supplied about their own cwd. Guard against a relative
+        # project_path too: derive_project_name() resolves relative paths
+        # against the SERVER's cwd, which under the systemd deployment is
+        # this checkout -- deriving from a relative path would misattribute
+        # every caller's row to "session-intelligence", the exact bug #48/#49
+        # fixed. A derived UNBOUND result is discarded rather than used, to
+        # avoid recreating the invisible-rows bug #48 fixed.
+        if (
+            not (session_id or session_name or project_name)
+            and not allow_unbound
+            and project_path
+            and project_path != UNKNOWN_PROJECT_PATH
+            and Path(project_path).is_absolute()
+        ):
+            derived_name = derive_project_name(project_path)
+            if derived_name != UNBOUND:
+                project_name = derived_name
+
         if session_id or session_name or project_name:
             resolved_ctx = await self._resolve_session_context(
                 session_id=session_id,

--- a/tests/test_session_recall_project_binding.py
+++ b/tests/test_session_recall_project_binding.py
@@ -130,6 +130,74 @@ async def test_create_then_log_uses_current_session(db):
 
 
 @pytest.mark.asyncio
+async def test_log_learning_with_absolute_project_path_derives_project_name(
+    db, tmp_path
+):
+    """No session identifier, but an absolute project_path: should derive a
+    project_name instead of raising, and must not bind to '_unbound_'."""
+    engine = _make_engine(db)
+    project_path = str(tmp_path)
+    result = await engine.session_log_learning(
+        category="error_fix",
+        learning_content="derive-project-name-probe",
+        project_path=project_path,
+    )
+    row = None
+    try:
+        assert result.status == "saved"
+
+        pool = db._ensure_connected()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT project_name FROM project_learnings WHERE id = $1",
+                result.id,
+            )
+        assert row is not None
+        assert row["project_name"] is not None
+        assert row["project_name"] != "_unbound_"
+    finally:
+        pool = db._ensure_connected()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM project_learnings WHERE id = $1", result.id
+            )
+            if row and row["project_name"]:
+                await conn.execute(
+                    "DELETE FROM sessions WHERE project_name = $1",
+                    row["project_name"],
+                )
+
+
+@pytest.mark.asyncio
+async def test_log_learning_without_project_path_raises(db):
+    """No session identifier and no project_path at all: must still raise."""
+    from core.session_engine import SessionContextRequiredError
+
+    engine = _make_engine(db)
+    with pytest.raises(SessionContextRequiredError):
+        await engine.session_log_learning(
+            category="error_fix",
+            learning_content="no-project-path-probe",
+            project_path=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_log_learning_with_relative_project_path_raises(db):
+    """A relative project_path must NOT be used for derivation (guard 3):
+    derive_project_name() would resolve it against the server's own cwd."""
+    from core.session_engine import SessionContextRequiredError
+
+    engine = _make_engine(db)
+    with pytest.raises(SessionContextRequiredError):
+        await engine.session_log_learning(
+            category="error_fix",
+            learning_content="relative-project-path-probe",
+            project_path="relative/path/to/project",
+        )
+
+
+@pytest.mark.asyncio
 async def test_log_decision_with_project_name_param_creates_correct_session(db):
     pn = f"test-proj-{uuid.uuid4().hex[:8]}"
     engine = _make_engine(db)


### PR DESCRIPTION
## Problem

`session_log_learning` raised `SessionContextRequiredError` whenever the caller supplied none of `session_id` / `session_name` / `project_name` and left `allow_unbound=False` (`session_engine.py:2731-2736`).

The Claude Code hooks call it in exactly that shape. All four sites —

- `session_intelligence_post_tool.py:249, 276, 316`
- `session_intelligence_agent_stop.py:197`

— pass `project_path=<the caller's cwd>` and no session identifier. They reach `/mcp`, the engine raises, `http_server.py` catches it into `{"status": "error"}` and returns **HTTP 200**, and the hook never reads the response body. Every learning those hooks have written since `allow_unbound` began defaulting to `False` was rejected and silently dropped.

Note `project_path` was never the problem: it is schema-declared, so the PR #45 validator passes it through. It simply does not satisfy session binding — it only fills the row's `project_path` column.

## Change

When no session identifier is given and `allow_unbound=False`, derive `project_name` from `project_path` via `core.project_naming.derive_project_name()` (added in #48) and resolve through it, rather than raising.

### Why deriving is safe *here*

#48 deliberately left the legacy `_get_or_create_current_session_id` path on the `_unbound_` sentinel, because that path *"can see nothing but the server process cwd, which under the systemd HTTP deployment is pinned to this checkout and would stamp `session-intelligence` onto every caller's session."*

That objection does not apply. `project_path` is data the **caller** supplied about their own working directory — the same kind of input as the `step_data["working_directory"]` that #48 *did* derive from at the one site it fixed.

### Guards

Derivation is skipped, falling through to the original raise, unless **all** hold:

1. `project_path` is truthy
2. `project_path != UNKNOWN_PROJECT_PATH` (the `"_unknown_"` sentinel)
3. `Path(project_path).is_absolute()`

Guard 3 is load-bearing: `derive_project_name()` resolves a relative path against the **server's** cwd via its parent probe, which would reintroduce precisely the misattribution #48 and #49 fixed. There is a test pinning it.

A derived result of `UNBOUND` is discarded rather than used — binding to `_unbound_` would recreate the invisible-rows bug #48 closed.

## Verification

The tests in `tests/test_session_recall_project_binding.py` are gated on `POSTGRES_DSN` (read directly at line 10) and **silently skip without it** — an initial run reported "460 passed, 65 skipped" with all three new tests sitting inside the skips, proving nothing.

Re-run against a throwaway `session_intelligence_test` database (created, used, dropped; production untouched):

```
8 passed in 1.49s
```

0 failed, 0 skipped, 0 errors. All three new tests genuinely executed:

- `test_log_learning_with_absolute_project_path_derives_project_name` — PASSED
- `test_log_learning_without_project_path_raises` — PASSED
- `test_log_learning_with_relative_project_path_raises` — PASSED

The other five in the file passed too, including `test_log_without_create_raises_without_allow_unbound` — direct evidence the error contract is preserved, not weakened. The other two pinned guards (`test_pre_resolver_guard.py:46`, `test_session_resolver.py:157`) are SQLite-backed and pass in the normal suite.

## Scope

Untouched: `session_log_decision` (its schema has no `project_path`, so this call shape cannot arise), `session_create_notebook`, `_resolve_session_context`, the legacy `_get_or_create_current_session_id` path, and the hook files themselves.

## Follow-up

The four hook sites still pass only `project_path`. They now work because the engine derives from it, but nothing stops a future caller from hitting the raise. Whether the hooks should also pass `project_name` explicitly is a separate, smaller decision.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)