### PR TITLE
fix(engine): accept project_path on session_log_decision (closes #53)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -1262,6 +1262,7 @@ class SessionIntelligenceEngine:
         link_artifacts: list[str] | None = None,
         project_name: str | None = None,
         session_name: str | None = None,
+        project_path: str | None = None,
         allow_unbound: bool = False,
     ) -> DecisionResult:
         """
@@ -1270,7 +1271,8 @@ class SessionIntelligenceEngine:
         Consolidates: claudecode_log_decision, claudecode_log_workflow_step
         Enhanced: Adds decision impact analysis and relationship mapping
 
-        Pass at least one of session_id, session_name, or project_name.
+        Pass at least one of session_id, session_name, project_name, or
+        project_path.
         Use allow_unbound=True to opt into the legacy unbound fallback (deprecated).
         """
         try:
@@ -1279,6 +1281,34 @@ class SessionIntelligenceEngine:
                 context = {"description": context}
 
             decision_id = f"decision-{uuid.uuid4().hex[:8]}"
+
+            # No explicit session identifier: try to derive a project_name from
+            # a caller-supplied project_path before falling back to anything
+            # ambient. This mirrors session_log_learning (issue #53 restored the
+            # symmetry that PR #52 established there but did not extend here);
+            # see that method for the full rationale. The same two guards apply:
+            # a relative project_path is rejected because derive_project_name()
+            # resolves it against the SERVER's cwd -- under the systemd
+            # deployment that is this checkout, so deriving from a relative path
+            # would misattribute every caller's row to "session-intelligence",
+            # the exact bug #48/#49 fixed -- and a derived UNBOUND result is
+            # discarded rather than used, to avoid recreating the invisible-rows
+            # bug #48 fixed.
+            #
+            # This runs BEFORE the in-process-session guard below so that an
+            # explicit project_path wins over the ambient current session. That
+            # reorders nothing in practice: project_path was previously a
+            # TypeError on this method, so no existing caller can reach here.
+            if (
+                not (session_id or session_name or project_name)
+                and not allow_unbound
+                and project_path
+                and project_path != UNKNOWN_PROJECT_PATH
+                and Path(project_path).is_absolute()
+            ):
+                derived_name = derive_project_name(project_path)
+                if derived_name != UNBOUND:
+                    project_name = derived_name
 
             # If no identifier given but a current session was created by THIS
             # process, thread it as session_id so the resolver validates rather

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -202,6 +202,15 @@ class LeanMCPInterface:
                             "creates a new session if not found (and create_if_missing=True)."
                         ),
                     },
+                    "project_path": {
+                        "type": "string",
+                        "description": (
+                            "Absolute path to the caller's project. When no session_id, "
+                            "session_name, or project_name is given, project_name is "
+                            "derived from this path. Relative paths are ignored (they "
+                            "would resolve against the server's cwd, not the caller's)."
+                        ),
+                    },
                     "allow_unbound": {
                         "type": "boolean",
                         "default": False,

--- a/tests/regression/test_issue_53_decision_project_path.py
+++ b/tests/regression/test_issue_53_decision_project_path.py
@@ -1,0 +1,138 @@
+"""
+Regression tests for issue #53: session_log_decision rejects project_path,
+diverging from session_log_learning after PR #52.
+
+Verifies session_log_decision now accepts project_path and derives
+project_name from it symmetrically with session_log_learning, subject to
+the same two guards (absolute path required, derived UNBOUND discarded).
+"""
+
+import pytest
+
+from core.project_naming import UNBOUND, derive_project_name
+from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory SQLite database, initialized and cleaned up per test."""
+    backend = SQLiteBackend(db_path=":memory:")
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+def engine(db, monkeypatch: pytest.MonkeyPatch) -> SessionIntelligenceEngine:
+    """Engine wired to in-memory SQLite, no filesystem."""
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENTS_DIR", "/tmp/nonexistent-agents")
+    return SessionIntelligenceEngine(
+        repository_path=None,
+        use_filesystem=False,
+        database=db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: project_path is accepted without raising
+# ---------------------------------------------------------------------------
+
+
+async def test_log_decision_accepts_project_path(engine, db, tmp_path):
+    """
+    session_log_decision(project_path=...) must not raise TypeError (the
+    parameter did not exist before this fix) and must produce a bound
+    session, not the '_unbound_' fallback.
+    """
+    result = await engine.session_log_decision(
+        decision="use dataclasses for frozen value objects",
+        project_path=str(tmp_path),
+    )
+
+    assert result.decision_id != "error"
+    assert result.session_id != "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: project_path derives the same project_name as session_log_learning
+# ---------------------------------------------------------------------------
+
+
+async def test_decision_project_path_derives_same_name_as_learning(engine, db, tmp_path):
+    """
+    For the same absolute project_path, session_log_decision must derive
+    the same project_name as session_log_learning does.
+    """
+    expected_name = derive_project_name(str(tmp_path))
+    assert expected_name != UNBOUND
+
+    learn_result = await engine.session_log_learning(
+        category="pattern",
+        learning_content="x",
+        project_path=str(tmp_path),
+    )
+    assert learn_result.status == "saved"
+
+    decision_result = await engine.session_log_decision(
+        decision="y",
+        project_path=str(tmp_path),
+    )
+
+    session = await db.get_session(decision_result.session_id)
+    assert session is not None
+    assert session["project_name"] == expected_name
+
+
+# ---------------------------------------------------------------------------
+# Test 3: a relative project_path is ignored (guards #48/#49 misattribution)
+# ---------------------------------------------------------------------------
+
+
+async def test_decision_relative_project_path_is_ignored(engine, db):
+    """
+    A relative project_path must NOT be used to derive a project_name,
+    since derive_project_name() would resolve it against the server's cwd
+    rather than the caller's — the exact misattribution bug #48/#49 fixed.
+
+    With the relative path correctly ignored and no other session
+    identifier supplied, session_log_decision falls through to the same
+    "at least one identifier required" guard as session_log_learning and
+    raises SessionContextRequiredError rather than silently creating a
+    session under the misattributed name.
+    """
+    relative_path = "some/relative/dir"
+    misattributed_name = derive_project_name(relative_path)
+    assert misattributed_name != UNBOUND  # sanity: this would be a real (wrong) name
+
+    with pytest.raises(SessionContextRequiredError):
+        await engine.session_log_decision(
+            decision="z",
+            project_path=relative_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: explicit project_name wins over project_path
+# ---------------------------------------------------------------------------
+
+
+async def test_decision_explicit_project_name_wins_over_project_path(engine, db, tmp_path):
+    """
+    When both project_name and project_path are supplied, the explicit
+    project_name must win — project_path is only a fallback source.
+    """
+    decision_result = await engine.session_log_decision(
+        decision="w",
+        project_name="explicit-proj",
+        project_path=str(tmp_path),
+    )
+
+    session = await db.get_session(decision_result.session_id)
+    assert session is not None
+    assert session["project_name"] == "explicit-proj"


### PR DESCRIPTION
Closes #53.

## Problem

#52 taught `session_log_learning` to derive `project_name` from a caller-supplied `project_path` instead of rejecting the write. That fix was never extended to its sibling, so `session_log_decision` kept rejecting the keyword outright:

```
SessionIntelligenceEngine.session_log_decision() got an unexpected keyword argument
'project_path'. Did you mean 'project_name'?
```

The two tools are documented and used as a pair — `CLAUDE.md` presents them side by side as the pair to call before ending a session — so after #52 they had divergent binding contracts and a caller written against one broke on the other.

The failure shape made it worse: the transport returns `"status": "success"` with the rejection nested in `result.error`, so a caller checking only the envelope treats the dropped write as a successful one. (Adjacent to #51, but on the tool-dispatch path rather than the HTTP path.)

This was found by accident — by hitting it while logging a decision — not by a sweep. The issue keeps an open checkbox for auditing the remaining `session_*` tools for the same asymmetry.

## Change

Mirror the #52 derivation on `session_log_decision`, with both of its guards intact:

- **Relative `project_path` is ignored.** `derive_project_name()` resolves relative paths against the *server's* cwd — under the systemd deployment that is this checkout — so deriving from one would misattribute every caller's row to `session-intelligence`, the exact bug #48/#49 fixed.
- **A derived `UNBOUND` result is discarded** rather than used, to avoid recreating the invisible-rows bug #48 fixed.

The derivation runs *before* the in-process-session guard, so an explicit `project_path` wins over the ambient current session. That reorders nothing in practice: `project_path` was previously a `TypeError` on this method, so no existing caller could reach the new branch.

| File | Change |
|---|---|
| `src/core/session_engine.py` | `project_path` parameter + derivation block on `session_log_decision` |
| `src/lean_mcp_interface.py` | declare `project_path` in the `session_log_decision` schema (`required` unchanged) |
| `tests/regression/test_issue_53_decision_project_path.py` | new, 4 tests |

## Tests

| Test | Asserts |
|---|---|
| `test_log_decision_accepts_project_path` | no `TypeError`; session is bound, not `_unbound_` |
| `test_decision_project_path_derives_same_name_as_learning` | the symmetry itself — same path ⇒ same derived `project_name` as `session_log_learning` |
| `test_decision_relative_project_path_is_ignored` | relative path never reaches `derive_project_name`; falls through to `SessionContextRequiredError`. Sanity-asserts the relative path *would* have produced a real (wrong) name, so the test proves the guard rather than an accident |
| `test_decision_explicit_project_name_wins_over_project_path` | explicit `project_name` takes precedence |

Full suite: **466 passed, 65 skipped**, against **531 collected** — reconciled, so nothing was silently dropped from collection.

## Note on acceptance criteria

Issue #53 lists `session_recall(project_name=<derived>)` surfacing a `project_path`-only decision. The tests assert the stronger, more direct property — that the decision's bound session carries the correctly derived `project_name` — because recall of decisions from an active session has a separate known defect that would make a recall-based assertion test the wrong thing. The binding is what this change is responsible for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)