### PR TITLE
fix(persistence): make migrate_all honest (closes #50)

### DIFF
--- a/src/persistence/base.py
+++ b/src/persistence/base.py
@@ -191,6 +191,19 @@ class DatabaseBackend(Protocol):
         """Query notes by date across sessions."""
         ...
 
+    async def query_notes(self, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Query notes across all sessions, ordered by id.
+
+        Unlike query_notes_by_date this does NOT join sessions, so notes whose
+        session row is missing (orphans) are still returned. Paginate by
+        increasing offset until fewer than `limit` rows are returned.
+        """
+        ...
+
+    async def query_mcp_sessions(self, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Query MCP session mappings, ordered by a stable key. Paginated like query_notes."""
+        ...
+
     # Agent execution operations
     async def save_agent_execution(self, execution_data: dict[str, Any]) -> None:
         """Save agent execution record."""

--- a/src/persistence/migration.py
+++ b/src/persistence/migration.py
@@ -23,7 +23,7 @@ import argparse
 import asyncio
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +36,15 @@ logger = logging.getLogger(__name__)
 class MigrationManager:
     """Handles database migrations between backends and locations."""
 
+    ENTITIES: tuple[str, ...] = (
+        "sessions",
+        "decisions",
+        "metrics",
+        "notes",
+        "agent_executions",
+        "mcp_sessions",
+    )
+
     def __init__(
         self,
         source: DatabaseBackend,
@@ -43,17 +52,49 @@ class MigrationManager:
     ) -> None:
         self.source = source
         self.target = target
-        self.stats: dict[str, int] = {
-            "sessions": 0,
-            "decisions": 0,
-            "metrics": 0,
-            "notes": 0,
-            "agent_executions": 0,
-            "mcp_sessions": 0,
-        }
+        self.stats: dict[str, int] = dict.fromkeys(self.ENTITIES, 0)
+        # Per-entity counts of records that raised while saving to target.
+        self.failed: dict[str, int] = dict.fromkeys(self.ENTITIES, 0)
+        # Human-readable messages: both save failures and detected truncation.
+        self.warnings: list[str] = []
+        # Set when any query hit its limit and we cannot prove nothing was
+        # left behind (no offset support on that reader).
+        self.truncated = False
 
-    async def migrate_all(self, batch_size: int = 100) -> dict[str, Any]:
-        """Migrate all data from source to target."""
+    def _record_failure(self, entity: str, message: str) -> None:
+        """Record a record that raised while being saved to the target."""
+        self.failed[entity] += 1
+        self.warnings.append(message)
+        logger.warning(message)
+
+    def _record_truncation(self, entity: str, message: str) -> None:
+        """Record that a query may have left records behind (hit its cap)."""
+        self.truncated = True
+        self.warnings.append(message)
+        logger.warning(message)
+
+    async def migrate_all(
+        self, batch_size: int = 100, scan_limit: int = 10000
+    ) -> dict[str, Any]:
+        """Migrate all data from source to target.
+
+        Two distinct concepts, not to be confused:
+
+        - `batch_size` is the page size for the genuinely paginated readers
+          (`query_notes`, `query_mcp_sessions`), which loop by `offset` until
+          exhausted. It bounds memory per page, NOT the total number of rows
+          migrated — pagination continues until the source is exhausted
+          regardless of its value.
+        - `scan_limit` is a hard cap for readers that expose no `offset`
+          (`query_sessions`, `query_decisions_by_category`,
+          `query_decisions_by_session`, `query_metrics_by_session`,
+          `query_agent_executions`). These readers cannot be paginated with
+          the current read interface, so hitting `scan_limit` is real
+          truncation and is reported via `status="partial"` and a warning.
+          Properly paginating them requires adding `offset` support to the
+          read interface in `base.py`, which is deliberately out of scope
+          for this change.
+        """
         start_time = datetime.now()
 
         logger.info("Starting migration...")
@@ -61,139 +102,236 @@ class MigrationManager:
         logger.info(f"Target: {type(self.target).__name__}")
 
         # Migrate in dependency order
-        await self._migrate_sessions(batch_size)
-        await self._migrate_decisions(batch_size)
-        await self._migrate_metrics(batch_size)
-        await self._migrate_notes(batch_size)
-        await self._migrate_agent_executions(batch_size)
-        await self._migrate_mcp_sessions(batch_size)
+        await self._migrate_sessions(batch_size, scan_limit)
+        await self._migrate_decisions(batch_size, scan_limit)
+        await self._migrate_metrics(batch_size, scan_limit)
+        await self._migrate_notes(batch_size, scan_limit)
+        await self._migrate_agent_executions(batch_size, scan_limit)
+        await self._migrate_mcp_sessions(batch_size, scan_limit)
 
         duration = (datetime.now() - start_time).total_seconds()
 
-        result = {
-            "status": "success",
+        is_clean = sum(self.failed.values()) == 0 and not self.truncated
+        result: dict[str, Any] = {
+            "status": "success" if is_clean else "partial",
             "duration_seconds": duration,
             "records_migrated": self.stats,
             "total_records": sum(self.stats.values()),
         }
+        if not is_clean:
+            result["warnings"] = list(self.warnings)
+            result["failed"] = {k: v for k, v in self.failed.items() if v}
 
         logger.info(f"Migration completed in {duration:.2f}s")
         logger.info(f"Total records migrated: {sum(self.stats.values())}")
 
         return result
 
-    async def _migrate_sessions(self, batch_size: int) -> None:
+    async def _migrate_sessions(self, batch_size: int, scan_limit: int) -> None:
         """Migrate sessions table."""
         logger.info("Migrating sessions...")
-        sessions = await self.source.query_sessions(limit=10000)
+        sessions = await self.source.query_sessions(limit=scan_limit)
+        if len(sessions) >= scan_limit:
+            self._record_truncation(
+                "sessions",
+                f"sessions: query_sessions returned {len(sessions)} rows at "
+                f"scan_limit={scan_limit}; query_sessions has no offset support, "
+                "so the source may contain more sessions than were migrated",
+            )
 
         for session in sessions:
             try:
                 await self.target.save_session(session)
                 self.stats["sessions"] += 1
             except Exception as e:
-                logger.warning(f"Failed to migrate session {session.get('id')}: {e}")
+                self._record_failure(
+                    "sessions", f"Failed to migrate session {session.get('id')}: {e}"
+                )
 
         logger.info(f"  Migrated {self.stats['sessions']} sessions")
 
-    async def _migrate_decisions(self, batch_size: int) -> None:
-        """Migrate decisions table."""
+    async def _migrate_decisions(self, batch_size: int, scan_limit: int) -> None:
+        """Migrate decisions table.
+
+        Decisions are collected into a dict keyed by id BEFORE saving, so a
+        decision found by both the category loop and the session fallback
+        loop (uncategorized decisions) is saved and counted exactly once.
+        """
         logger.info("Migrating decisions...")
 
-        # Query decisions by common categories
         categories = [
             "architecture",
             "implementation",
             "testing",
             "deployment",
             "refactoring",
-            None,  # Uncategorized
         ]
 
-        for category in categories:
-            if category:
-                decisions = await self.source.query_decisions_by_category(category, limit=10000)
-            else:
-                # Get all decisions not in known categories via session
-                sessions = await self.source.query_sessions(limit=10000)
-                decisions = []
-                for session in sessions:
-                    session_decisions = await self.source.query_decisions_by_session(
-                        session["id"], limit=1000
-                    )
-                    decisions.extend(session_decisions)
+        collected: dict[Any, dict[str, Any]] = {}
 
+        for category in categories:
+            decisions = await self.source.query_decisions_by_category(category, limit=scan_limit)
+            if len(decisions) >= scan_limit:
+                self._record_truncation(
+                    "decisions",
+                    f"decisions: category '{category}' returned {len(decisions)} rows "
+                    f"at scan_limit={scan_limit}; source may contain more",
+                )
             for decision in decisions:
-                try:
-                    await self.target.save_decision(decision)
-                    self.stats["decisions"] += 1
-                except Exception as e:
-                    logger.warning(f"Failed to migrate decision {decision.get('id')}: {e}")
+                collected[decision.get("id")] = decision
+
+        # Uncategorized decisions: pull all decisions per session and keep
+        # only the ones not already collected above.
+        sessions = await self.source.query_sessions(limit=scan_limit)
+        if len(sessions) >= scan_limit:
+            self._record_truncation(
+                "decisions",
+                f"decisions: query_sessions returned {len(sessions)} rows at "
+                f"scan_limit={scan_limit} while scanning for uncategorized decisions; "
+                "source may contain more sessions than were scanned",
+            )
+        for session in sessions:
+            session_decisions = await self.source.query_decisions_by_session(
+                session["id"], limit=scan_limit
+            )
+            if len(session_decisions) >= scan_limit:
+                self._record_truncation(
+                    "decisions",
+                    f"decisions: session {session['id']} returned "
+                    f"{len(session_decisions)} decisions at scan_limit={scan_limit}; "
+                    "source may contain more",
+                )
+            for decision in session_decisions:
+                collected.setdefault(decision.get("id"), decision)
+
+        for decision in collected.values():
+            try:
+                await self.target.save_decision(decision)
+                self.stats["decisions"] += 1
+            except Exception as e:
+                self._record_failure(
+                    "decisions", f"Failed to migrate decision {decision.get('id')}: {e}"
+                )
 
         logger.info(f"  Migrated {self.stats['decisions']} decisions")
 
-    async def _migrate_metrics(self, batch_size: int) -> None:
+    async def _migrate_metrics(self, batch_size: int, scan_limit: int) -> None:
         """Migrate metrics table."""
         logger.info("Migrating metrics...")
 
-        # Get metrics via sessions
-        sessions = await self.source.query_sessions(limit=10000)
+        sessions = await self.source.query_sessions(limit=scan_limit)
+        if len(sessions) >= scan_limit:
+            self._record_truncation(
+                "metrics",
+                f"metrics: query_sessions returned {len(sessions)} rows at "
+                f"scan_limit={scan_limit}; source may contain more sessions than were scanned",
+            )
         for session in sessions:
-            metrics = await self.source.query_metrics_by_session(session["id"], limit=1000)
+            metrics = await self.source.query_metrics_by_session(session["id"], limit=scan_limit)
+            if len(metrics) >= scan_limit:
+                self._record_truncation(
+                    "metrics",
+                    f"metrics: session {session['id']} returned {len(metrics)} metrics "
+                    f"at scan_limit={scan_limit}; source may contain more",
+                )
             for metric in metrics:
                 try:
                     await self.target.save_metrics(metric)
                     self.stats["metrics"] += 1
                 except Exception as e:
-                    logger.warning(f"Failed to migrate metric: {e}")
+                    self._record_failure("metrics", f"Failed to migrate metric: {e}")
 
         logger.info(f"  Migrated {self.stats['metrics']} metrics")
 
-    async def _migrate_notes(self, batch_size: int) -> None:
-        """Migrate notes table."""
+    async def _migrate_notes(self, batch_size: int, scan_limit: int) -> None:
+        """Migrate notes table.
+
+        Paginated full scan via query_notes (not joined to sessions, so
+        orphaned notes are included), superseding the old 365-day walk which
+        silently dropped anything older than a year, capped each day at
+        1000, and never surfaced the cap.
+        """
         logger.info("Migrating notes...")
 
-        # Get notes for recent dates
-        from datetime import timedelta
-
-        # Anchor the scan to UTC: note.date is derived from datetime.now(UTC).
-        # Using naive local time here meant that after local/UTC date rollover
-        # the newest notes were dated "ahead" of the scan's starting point and,
-        # because the scan only walks backward, were silently never migrated.
-        for days_ago in range(365):  # Last year
-            date = (datetime.now(UTC) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
-            notes = await self.source.query_notes_by_date(date, limit=1000)
+        offset = 0
+        while True:
+            notes = await self.source.query_notes(limit=batch_size, offset=offset)
+            if not notes:
+                break
 
             for note in notes:
                 try:
                     await self.target.save_note(note)
                     self.stats["notes"] += 1
                 except Exception as e:
-                    logger.warning(f"Failed to migrate note: {e}")
+                    self._record_failure(
+                        "notes", f"Failed to migrate note {note.get('id')}: {e}"
+                    )
+
+            if len(notes) < batch_size:
+                break
+            offset += batch_size
+
+        # notes.id is SERIAL on PostgreSQL; explicit-id inserts (preserving
+        # source ids for idempotency) don't advance the sequence. Resync it
+        # if the target supports it. SQLite's AUTOINCREMENT bookkeeping is
+        # updated automatically on explicit-id inserts, so no equivalent call
+        # exists there — this is not an oversight.
+        resync = getattr(self.target, "resync_notes_sequence", None)
+        if resync is not None:
+            await resync()
 
         logger.info(f"  Migrated {self.stats['notes']} notes")
 
-    async def _migrate_agent_executions(self, batch_size: int) -> None:
+    async def _migrate_agent_executions(self, batch_size: int, scan_limit: int) -> None:
         """Migrate agent_executions table."""
         logger.info("Migrating agent executions...")
 
-        executions = await self.source.query_agent_executions(limit=10000)
+        executions = await self.source.query_agent_executions(limit=scan_limit)
+        if len(executions) >= scan_limit:
+            self._record_truncation(
+                "agent_executions",
+                f"agent_executions: query_agent_executions returned "
+                f"{len(executions)} rows at scan_limit={scan_limit}; source may contain more",
+            )
         for execution in executions:
             try:
                 await self.target.save_agent_execution(execution)
                 self.stats["agent_executions"] += 1
             except Exception as e:
-                logger.warning(f"Failed to migrate agent execution {execution.get('id')}: {e}")
+                self._record_failure(
+                    "agent_executions",
+                    f"Failed to migrate agent execution {execution.get('id')}: {e}",
+                )
 
         logger.info(f"  Migrated {self.stats['agent_executions']} agent executions")
 
-    async def _migrate_mcp_sessions(self, batch_size: int) -> None:
-        """Migrate mcp_sessions table."""
+    async def _migrate_mcp_sessions(self, batch_size: int, scan_limit: int) -> None:
+        """Migrate mcp_sessions table via a paginated full scan."""
         logger.info("Migrating MCP sessions...")
 
-        # MCP sessions don't have a query_all method, so we skip or implement differently
-        # For now, we'll log that this needs manual handling if needed
-        logger.info("  MCP sessions migration: manual review recommended")
+        offset = 0
+        while True:
+            mcp_sessions = await self.source.query_mcp_sessions(limit=batch_size, offset=offset)
+            if not mcp_sessions:
+                break
+
+            for mcp_session in mcp_sessions:
+                try:
+                    await self.target.save_mcp_session(mcp_session)
+                    self.stats["mcp_sessions"] += 1
+                except Exception as e:
+                    self._record_failure(
+                        "mcp_sessions",
+                        f"Failed to migrate MCP session "
+                        f"{mcp_session.get('mcp_session_id')}: {e}",
+                    )
+
+            if len(mcp_sessions) < batch_size:
+                break
+            offset += batch_size
+
+        logger.info(f"  Migrated {self.stats['mcp_sessions']} MCP sessions")
 
 
 async def migrate_local_to_global(

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -800,7 +800,18 @@ class PostgreSQLBackend(BaseDatabaseBackend):
     # Notes operations
 
     async def save_note(self, note_data: dict[str, Any]) -> None:
-        """Save a session note."""
+        """Save a session note.
+
+        Idempotent when note_data carries a non-None "id": the row is
+        upserted by id via ON CONFLICT. Without an "id" this is a plain
+        insert, preserving prior behaviour for normal note creation — two
+        id-less notes with identical content still produce two rows.
+
+        NOTE: notes.id is SERIAL. Explicit-id inserts do not advance the
+        sequence, so callers that preserve ids across a bulk load (e.g. the
+        migrator) must call resync_notes_sequence() afterward or later
+        auto-assigned inserts can collide with an existing id.
+        """
         pool = self._ensure_connected()
 
         from datetime import date
@@ -809,16 +820,51 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         if isinstance(note_date, str):
             note_date = date.fromisoformat(note_date)
 
+        note_id = note_data.get("id")
+        async with pool.acquire() as conn:
+            if note_id is not None:
+                await conn.execute(
+                    """
+                    INSERT INTO notes (id, session_id, date, content, tags)
+                    VALUES ($1, $2, $3, $4, $5)
+                    ON CONFLICT (id) DO UPDATE SET
+                        session_id = EXCLUDED.session_id,
+                        date = EXCLUDED.date,
+                        content = EXCLUDED.content,
+                        tags = EXCLUDED.tags
+                    """,
+                    note_id,
+                    note_data["session_id"],
+                    note_date,
+                    note_data["content"],
+                    json.dumps(note_data.get("tags", [])),
+                )
+            else:
+                await conn.execute(
+                    """
+                    INSERT INTO notes (session_id, date, content, tags)
+                    VALUES ($1, $2, $3, $4)
+                    """,
+                    note_data["session_id"],
+                    note_date,
+                    note_data["content"],
+                    json.dumps(note_data.get("tags", [])),
+                )
+
+    async def resync_notes_sequence(self) -> None:
+        """Resync the notes.id SERIAL sequence after explicit-id inserts.
+
+        Explicit-id inserts (e.g. from save_note during migration) bypass the
+        sequence, so subsequent auto-assigned inserts could otherwise collide
+        with a preserved id. Call this once after any bulk load that preserves
+        ids.
+        """
+        pool = self._ensure_connected()
+
         async with pool.acquire() as conn:
             await conn.execute(
-                """
-                INSERT INTO notes (session_id, date, content, tags)
-                VALUES ($1, $2, $3, $4)
-                """,
-                note_data["session_id"],
-                note_date,
-                note_data["content"],
-                json.dumps(note_data.get("tags", [])),
+                "SELECT setval(pg_get_serial_sequence('notes','id'), "
+                "COALESCE((SELECT MAX(id) FROM notes), 0) + 1, false)"
             )
 
     async def query_notes_by_date(self, date: str, limit: int = 100) -> list[dict[str, Any]]:
@@ -846,6 +892,25 @@ class PostgreSQLBackend(BaseDatabaseBackend):
             for row in rows:
                 result = self._from_record(row)
                 # Normalize DATE column: PostgreSQL returns datetime.date, tests expect string
+                if "date" in result and not isinstance(result["date"], str):
+                    result["date"] = str(result["date"])
+                results.append(result)
+            return results
+
+    async def query_notes(self, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Query notes across all sessions, ordered by id. Not joined to sessions,
+        so orphaned notes (missing session row) are still returned."""
+        pool = self._ensure_connected()
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM notes ORDER BY id LIMIT $1 OFFSET $2",
+                limit,
+                offset,
+            )
+            results = []
+            for row in rows:
+                result = self._from_record(row)
                 if "date" in result and not isinstance(result["date"], str):
                     result["date"] = str(result["date"])
                 results.append(result)
@@ -1456,6 +1521,18 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 engine_session_id,
                 mcp_session_id,
             )
+
+    async def query_mcp_sessions(self, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Query MCP session mappings, ordered by mcp_session_id (the primary key)."""
+        pool = self._ensure_connected()
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM mcp_sessions ORDER BY mcp_session_id LIMIT $1 OFFSET $2",
+                limit,
+                offset,
+            )
+            return [self._from_record(row) for row in rows]
 
     # Maintenance operations
 

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -598,6 +598,10 @@ class SQLiteBackend(BaseDatabaseBackend):
             (id, session_id, timestamp, category, description, rationale,
              context, impact_level, artifacts)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                description = excluded.description,
+                rationale = excluded.rationale,
+                context = excluded.context
         """,
             (
                 decision_data.get("decision_id") or decision_data.get("id"),
@@ -715,21 +719,46 @@ class SQLiteBackend(BaseDatabaseBackend):
     # Notes operations
 
     async def save_note(self, note_data: dict[str, Any]) -> None:
-        """Save a session note."""
+        """Save a session note.
+
+        Idempotent when note_data carries a non-None "id": the row is
+        upserted by id (SQLite AUTOINCREMENT bookkeeping in sqlite_sequence
+        is updated automatically on explicit-id inserts, so no sequence
+        resync is needed here, unlike PostgreSQL's SERIAL). Without an "id"
+        this is a plain insert, preserving prior behaviour for normal note
+        creation — two id-less notes with identical content still produce
+        two rows.
+        """
         conn = self._ensure_connected()
 
-        await conn.execute(
-            """
-            INSERT INTO notes (session_id, date, content, tags)
-            VALUES (?, ?, ?, ?)
-        """,
-            (
-                note_data["session_id"],
-                note_data.get("date", datetime.now().strftime("%Y-%m-%d")),
-                note_data["content"],
-                self._serialize_json(note_data.get("tags", [])),
-            ),
-        )
+        note_id = note_data.get("id")
+        if note_id is not None:
+            await conn.execute(
+                """
+                INSERT OR REPLACE INTO notes (id, session_id, date, content, tags)
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (
+                    note_id,
+                    note_data["session_id"],
+                    note_data.get("date", datetime.now().strftime("%Y-%m-%d")),
+                    note_data["content"],
+                    self._serialize_json(note_data.get("tags", [])),
+                ),
+            )
+        else:
+            await conn.execute(
+                """
+                INSERT INTO notes (session_id, date, content, tags)
+                VALUES (?, ?, ?, ?)
+            """,
+                (
+                    note_data["session_id"],
+                    note_data.get("date", datetime.now().strftime("%Y-%m-%d")),
+                    note_data["content"],
+                    self._serialize_json(note_data.get("tags", [])),
+                ),
+            )
         await conn.commit()
 
     async def query_notes_by_date(self, date: str, limit: int = 100) -> list[dict[str, Any]]:
@@ -746,6 +775,18 @@ class SQLiteBackend(BaseDatabaseBackend):
             LIMIT ?
         """,
             (date, limit),
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    async def query_notes(self, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Query notes across all sessions, ordered by id. Not joined to sessions,
+        so orphaned notes (missing session row) are still returned."""
+        conn = self._ensure_connected()
+
+        cursor = await conn.execute(
+            "SELECT * FROM notes ORDER BY id LIMIT ? OFFSET ?",
+            (limit, offset),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
@@ -1118,6 +1159,17 @@ class SQLiteBackend(BaseDatabaseBackend):
             (engine_session_id, mcp_session_id),
         )
         await conn.commit()
+
+    async def query_mcp_sessions(self, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Query MCP session mappings, ordered by mcp_session_id (the primary key)."""
+        conn = self._ensure_connected()
+
+        cursor = await conn.execute(
+            "SELECT * FROM mcp_sessions ORDER BY mcp_session_id LIMIT ? OFFSET ?",
+            (limit, offset),
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
 
     # Duplicate methods removed - see lines 692-732 for session summary operations
 

--- a/tests/regression/test_issue_50_migrate_all_honest.py
+++ b/tests/regression/test_issue_50_migrate_all_honest.py
@@ -1,0 +1,276 @@
+"""
+Regression tests for issue #50: make migrate_all honest.
+
+Covers the headline acceptance criteria from the issue and its two review
+comments (all line numbers verified against de9fff5):
+
+- notes older than the old 365-day horizon are migrated
+- a day with more than 1000 notes is migrated in full (paginated reader)
+- re-running migrate_all does not duplicate notes
+- an orphaned note (dangling session_id) is surfaced by the migrator instead
+  of being silently invisible
+- save_decision is idempotent on SQLite (previously PostgreSQL-only)
+- migrate_all reports status="partial" with failure detail when an entity
+  fails, instead of silently claiming "success"
+
+Match the house style: in-memory SQLite backend, asyncio_mode = "auto" (from
+pyproject.toml) — no @pytest.mark.asyncio needed. See
+tests/regression/test_issue_53_decision_project_path.py.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from persistence.migration import MigrationManager
+from persistence.sqlite import SQLiteBackend
+from tests.persistence.contract_tests import _decision, _session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def source():
+    """Source in-memory SQLite backend."""
+    db = SQLiteBackend(db_path=":memory:")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def target():
+    """Target in-memory SQLite backend."""
+    db = SQLiteBackend(db_path=":memory:")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def manager(source, target):
+    return MigrationManager(source, target)
+
+
+# ---------------------------------------------------------------------------
+# Headline criterion: notes older than 365 days are migrated
+# ---------------------------------------------------------------------------
+
+
+async def test_note_older_than_365_days_is_migrated(source, target, manager):
+    """A note dated well past the old 365-day scan horizon is still migrated,
+    since _migrate_notes now paginates query_notes() instead of walking a
+    fixed one-year window of individual dates."""
+    sid = "sess-old-note-001"
+    await source.save_session(_session(session_id=sid))
+
+    old_date = (date.today() - timedelta(days=400)).isoformat()
+    await source.save_note({
+        "session_id": sid,
+        "date": old_date,
+        "content": "ancient note",
+        "tags": [],
+    })
+
+    result = await manager.migrate_all()
+
+    assert result["records_migrated"]["notes"] == 1
+    target_notes = await target.query_notes(limit=10)
+    assert any(n["content"] == "ancient note" for n in target_notes)
+
+
+# ---------------------------------------------------------------------------
+# A day with more than 1000 notes is migrated in full
+# ---------------------------------------------------------------------------
+
+
+async def test_more_than_1000_notes_in_a_day_migrated_in_full(source, target, manager):
+    """The old code capped each day's notes at limit=1000 via
+    query_notes_by_date. The paginated query_notes reader has no such cap."""
+    sid = "sess-many-notes-001"
+    await source.save_session(_session(session_id=sid))
+
+    total = 1005
+    same_date = "2026-01-01"
+    for i in range(total):
+        await source.save_note({
+            "session_id": sid,
+            "date": same_date,
+            "content": f"note-{i}",
+            "tags": [],
+        })
+
+    result = await manager.migrate_all(batch_size=500)
+
+    assert result["status"] == "success"
+    assert result["records_migrated"]["notes"] == total
+    target_notes = await target.query_notes(limit=2000)
+    assert len(target_notes) == total
+
+
+# ---------------------------------------------------------------------------
+# Re-running migrate_all does not duplicate notes
+# ---------------------------------------------------------------------------
+
+
+async def test_rerunning_migrate_all_does_not_duplicate_notes(source, target, manager):
+    """save_note is now idempotent by id, so a second migration run does not
+    produce duplicate rows in the target."""
+    sid = "sess-rerun-notes-001"
+    await source.save_session(_session(session_id=sid))
+    for i in range(5):
+        await source.save_note({
+            "session_id": sid,
+            "date": "2026-08-01",
+            "content": f"note-{i}",
+            "tags": [],
+        })
+
+    await manager.migrate_all()
+    first_count = len(await target.query_notes(limit=100))
+
+    manager2 = MigrationManager(source, target)
+    await manager2.migrate_all()
+    second_count = len(await target.query_notes(limit=100))
+
+    assert first_count == 5
+    assert second_count == first_count
+
+
+# ---------------------------------------------------------------------------
+# Orphaned note: dangling session_id
+# ---------------------------------------------------------------------------
+
+
+async def test_orphaned_note_surfaced_and_attempted(source, target, manager):
+    """An orphaned note (session_id with no matching session anywhere) was
+    previously invisible: query_notes_by_date INNER JOINs sessions, so the
+    migrator's own reader could never see it. query_notes (Part A, no join)
+    fixes that visibility gap.
+
+    FINDING: SQLiteBackend.initialize() sets PRAGMA foreign_keys=ON
+    (src/persistence/sqlite.py:331), and PostgreSQL's notes.session_id FK
+    (src/persistence/postgresql.py) is not optional. So a note whose
+    session does not exist ANYWHERE cannot actually be written to a target
+    that enforces referential integrity — inserting it raises a foreign key
+    violation regardless of how honest the migrator's bookkeeping is. The
+    honest outcome is therefore a *reported* failure (status="partial", one
+    notes failure counted, a specific warning message) rather than the old
+    behavior of the note vanishing with no trace at all.
+    """
+    sid = "sess-orphan-001"
+    await source.save_session(_session(session_id=sid))
+    await source.save_note({
+        "session_id": sid,
+        "date": "2026-05-01",
+        "content": "orphan note",
+        "tags": [],
+    })
+
+    # Break referential integrity in the source on purpose: disable FK
+    # enforcement just long enough to delete the session directly (bypassing
+    # delete_session's manual cascade), leaving the note dangling.
+    conn = source._connection
+    await conn.execute("PRAGMA foreign_keys=OFF")
+    await conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
+    await conn.commit()
+    await conn.execute("PRAGMA foreign_keys=ON")
+
+    assert await source.get_session(sid) is None  # confirmed gone from source
+
+    # Part A fix: the non-joined reader surfaces the orphan...
+    source_notes = await source.query_notes(limit=100)
+    assert any(n["content"] == "orphan note" for n in source_notes)
+    # ...while the old joined reader still cannot see it (unchanged contract).
+    by_date = await source.query_notes_by_date("2026-05-01", limit=100)
+    assert not any(n["content"] == "orphan note" for n in by_date)
+
+    result = await manager.migrate_all()
+
+    assert result["status"] == "partial"
+    assert result["failed"]["notes"] == 1
+    assert any("Failed to migrate note" in w for w in result["warnings"])
+    target_notes = await target.query_notes(limit=100)
+    assert not any(n["content"] == "orphan note" for n in target_notes)
+
+
+# ---------------------------------------------------------------------------
+# save_decision idempotence on SQLite
+# ---------------------------------------------------------------------------
+
+
+async def test_save_decision_twice_same_id_updates_not_duplicates_sqlite(source):
+    """save_decision called twice with the same id produces one row on
+    SQLite (updated, not duplicated) — matching PostgreSQL's existing
+    ON CONFLICT (id) DO UPDATE behaviour."""
+    sid = "sess-decision-idem-001"
+    await source.save_session(_session(session_id=sid))
+
+    dec = _decision(session_id=sid, decision_id="dec-fixed-001")
+    await source.save_decision(dec)
+
+    updated = dict(dec)
+    updated["description"] = "updated description"
+    await source.save_decision(updated)
+
+    rows = await source.query_decisions_by_session(sid, limit=10)
+    assert len(rows) == 1
+    assert rows[0]["description"] == "updated description"
+
+
+# ---------------------------------------------------------------------------
+# Honest failure reporting
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_size_does_not_cap_total_records_migrated(source, target, manager):
+    """Regression guard: `batch_size` must never act as a hard cap on the
+    total number of records migrated. `migrate_all()` with its DEFAULT
+    arguments (batch_size=100, scan_limit=10000) must migrate all 150
+    sessions and all 150 notes seeded here — well above batch_size=100 —
+    with nothing truncated at the much larger scan_limit."""
+    total = 150
+    for i in range(total):
+        sid = f"sess-batch-cap-{i:03d}"
+        await source.save_session(_session(session_id=sid))
+        await source.save_note({
+            "session_id": sid,
+            "date": "2026-08-01",
+            "content": f"note-{i}",
+            "tags": [],
+        })
+
+    result = await manager.migrate_all()
+
+    assert result["records_migrated"]["sessions"] == total
+    assert result["records_migrated"]["notes"] == total
+    assert result["status"] == "success"
+
+
+async def test_migrate_all_reports_partial_status_on_entity_failure(
+    source, target, manager, monkeypatch
+):
+    """When a save to the target raises, migrate_all must report
+    status != "success" with the failure surfaced in the result, instead of
+    swallowing the exception and claiming success."""
+    sid = "sess-failure-001"
+    await source.save_session(_session(session_id=sid))
+
+    async def failing_save_session(session_data):
+        raise RuntimeError("simulated target failure")
+
+    monkeypatch.setattr(target, "save_session", failing_save_session)
+
+    result = await manager.migrate_all()
+
+    assert result["status"] == "partial"
+    assert result["failed"]["sessions"] == 1
+    assert any("simulated target failure" in w for w in result["warnings"])
+    # records_migrated / total_records keys are preserved for existing callers
+    assert "records_migrated" in result
+    assert "total_records" in result

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -22,6 +22,7 @@ from tests.persistence.contract_tests import (
     _agent_learning,
     _agent_notebook,
     _decision,
+    _mcp_session,
     _metrics,
     _note,
     _session,
@@ -117,6 +118,7 @@ async def test_migrate_all_entity_types(source, target, manager):
     await source.save_metrics(_metrics(session_id=sid))
     await source.save_note(_note(session_id=sid))
     await source.save_agent_execution(_agent_execution(session_id=sid))
+    await source.save_mcp_session(_mcp_session(mcp_session_id="mcp-migrate-all-001"))
 
     result = await manager.migrate_all()
 
@@ -126,13 +128,18 @@ async def test_migrate_all_entity_types(source, target, manager):
     assert rm["metrics"] >= 1
     assert rm["notes"] >= 1
     assert rm["agent_executions"] >= 1
-    assert result["total_records"] >= 5
+    assert rm["mcp_sessions"] >= 1
+    assert result["total_records"] >= 6
 
 
 async def test_migrate_idempotent(source, target, manager):
-    """Migrating twice does not duplicate sessions in the target."""
+    """Migrating twice does not duplicate sessions, decisions, or notes in
+    the target."""
     sid = "sess-migrate-idem-001"
     await source.save_session(_session(session_id=sid))
+    dec = _decision(session_id=sid, category="architecture")
+    await source.save_decision(dec)
+    await source.save_note(_note(session_id=sid))
 
     # First migration
     await manager.migrate_all()
@@ -144,6 +151,14 @@ async def test_migrate_idempotent(source, target, manager):
     matching = [s for s in sessions if s["id"] == sid]
     # INSERT OR REPLACE means exactly one row
     assert len(matching) == 1
+
+    decisions = await target.query_decisions_by_session(sid, limit=1000)
+    matching_decisions = [d for d in decisions if d["id"] == dec["id"]]
+    assert len(matching_decisions) == 1
+
+    notes = await target.query_notes(limit=1000)
+    matching_notes = [n for n in notes if n["session_id"] == sid]
+    assert len(matching_notes) == 1
 
 
 async def test_migrate_preserves_data_integrity(source, target, manager):
@@ -197,10 +212,10 @@ async def test_migrate_decisions_by_category(source, target, manager):
 
     result = await manager.migrate_all()
 
-    # Decisions may be counted multiple times due to category iteration in
-    # _migrate_decisions (once per category + once via session fallback).
-    # What matters is that all decisions are present in the target.
-    assert result["records_migrated"]["decisions"] >= len(categories)
+    # _migrate_decisions collects by id before saving, so a decision found by
+    # both the category loop and the uncategorized-session fallback is saved
+    # exactly once.
+    assert result["records_migrated"]["decisions"] == len(categories)
     target_decisions = await target.query_decisions_by_session(sid)
     target_ids = {d["id"] for d in target_decisions}
     for did in decision_ids:


### PR DESCRIPTION
Closes #50. Addresses all seven defects in the issue plus the `save_decision` divergence from [the addendum comment](https://github.com/Claire-s-Monster/session-intelligence/issues/50#issuecomment-5208888503).

## Readers

Add paginated, **non-joined** `query_notes` and `query_mcp_sessions` to `base.py` and both backends. `query_notes_by_date` INNER JOINs `sessions`, so a note whose session row was missing was invisible to every caller — including the migrator's own reader. `query_notes` has no join and pages by `offset`, which retires the 365-day horizon, the per-day fan-out, and the per-day 1000 cap in one change.

## Idempotence

`save_note` upserts on `id` when one is supplied and keeps the existing plain `INSERT` when it is not. Migration is repeatable; two legitimately-identical notes still produce two rows. This resolves the open design question in the issue in favour of **preserving source ids** rather than a `(session_id, date, content)` natural key, matching how `sessions` and `decisions` already behave.

> **PostgreSQL sequence caveat — worth a reviewer's eye.** `notes.id` is `SERIAL`, and an explicit-id `INSERT` does **not** advance the backing sequence. Without a resync, preserving ids would fix migration idempotence while breaking the *next ordinary note write*, which would draw a already-used id from the sequence. `resync_notes_sequence()` runs `setval(pg_get_serial_sequence('notes','id'), MAX(id)+1)` after the notes pass. SQLite needs no equivalent (`AUTOINCREMENT` updates `sqlite_sequence` on explicit-id insert), and that asymmetry is commented so it isn't "fixed" later. Note this failure mode is invisible to migration tests — it only appears on the first normal write afterwards.

SQLite `save_decision` gains `ON CONFLICT(id) DO UPDATE`, matching PostgreSQL. It was previously a plain `INSERT` with an explicit `id`, so a re-run raised on the primary key, landed in the bare `except`, and the decision was neither updated nor counted.

## Honesty

Per-entity failure counts, a `warnings` list, and truncation detection. `status` is `"success"` only when nothing failed or was capped, otherwise `"partial"` with `warnings` and `failed`. `records_migrated` / `total_records` are unchanged for existing callers.

`_migrate_mcp_sessions` is now implemented rather than logging "manual review recommended" and reporting success. `_migrate_decisions` collects into an id-keyed dict before saving, so a decision found by both the category loop and the session fallback is saved and counted exactly once.

## `batch_size` vs `scan_limit`

These are deliberately separate and the docstring says so:

- **`batch_size`** (default 100) — page size for the genuinely paginated readers. Does **not** bound total rows migrated.
- **`scan_limit`** (default 10000) — hard cap for readers with no `offset` (`query_sessions`, `query_decisions_by_*`, `query_metrics_by_session`, `query_agent_executions`). Hitting it is real truncation and is reported.

An intermediate version of this branch conflated them, which would have cut default session coverage from 10000 to 100 — honestly reported as `partial`, but migrating 100× less data in a change whose whole point is to stop leaving data behind. `test_batch_size_does_not_cap_total_records_migrated` seeds 150 rows against the default `batch_size=100` so that regression cannot return silently.

Properly paginating those readers needs `offset` on the `base.py` read interface, which touches the shared read path used by the engine, not just the migrator. **Deliberately out of scope here** — reasonable followup.

## Orphaned notes: reported, not rescued

Stating this plainly because the issue's framing implies more. `SQLiteBackend.initialize()` sets `PRAGMA foreign_keys=ON` (`sqlite.py:331`) and PostgreSQL declares `notes.session_id ... REFERENCES sessions(id)`. A note whose session exists **nowhere** cannot be inserted into either target, however good the migrator's bookkeeping.

So the orphan goes from *silently invisible to the migrator's own reader* to *surfaced, attempted, and counted in `failed["notes"]` with a warning*. That is a real improvement and it is the honest ceiling. Actually rescuing orphans would mean synthesising placeholder session rows — a schema/semantics decision #50 does not pose, so it is not smuggled in here.

## Tests

Fixed the tests the issue calls dishonest:

| Test | Was | Now |
|---|---|---|
| `test_migrate_all_entity_types` | docstring said "all six entity types", asserted five | asserts `mcp_sessions` too |
| `test_migrate_decisions_by_category` | weakened to `>=` to tolerate the double-count | tightened to `==` |
| `test_migrate_idempotent` | sessions only | extended to notes and decisions |

New `tests/regression/test_issue_50_migrate_all_honest.py` (7 tests): >365-day note, >1000 notes in a day, re-run non-duplication, the orphan, SQLite `save_decision` idempotence, `partial` status on failure, and the `batch_size` cap guard.

**Full suite: 473 passed, 65 skipped, against 538 collected** — reconciled (`collected == passed + skipped + failed + xfailed`), so nothing was dropped from collection.

## Known cosmetic debt

`_migrate_notes` / `_migrate_mcp_sessions` accept `scan_limit` unused, and `_migrate_sessions` accepts `batch_size` unused — uniform six-method signatures preferred over special-casing three. No `ARG` lint rule is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)