### PR TITLE
fix(persistence): paginate the last five readers, drop scan_limit (closes #57)

### DIFF
--- a/src/persistence/base.py
+++ b/src/persistence/base.py
@@ -138,8 +138,14 @@ class DatabaseBackend(Protocol):
         limit: int = 50,
         project_path: str | None = None,
         status: str | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
-        """Query sessions with optional filters."""
+        """Query sessions with optional filters.
+
+        Ordered by started_at DESC with `id` as a tiebreaker, so paginating by
+        `offset` cannot skip or repeat rows that share a timestamp. Paginate by
+        increasing offset until fewer than `limit` rows are returned.
+        """
         ...
 
     async def get_active_session_for_project(self, project_path: str) -> dict[str, Any] | None:
@@ -156,15 +162,23 @@ class DatabaseBackend(Protocol):
         ...
 
     async def query_decisions_by_category(
-        self, category: str, limit: int = 100
+        self, category: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
-        """Query decisions by category across sessions."""
+        """Query decisions by category across sessions.
+
+        Ordered by timestamp DESC with `id` as a tiebreaker; paginated like
+        query_sessions.
+        """
         ...
 
     async def query_decisions_by_session(
-        self, session_id: str, limit: int = 100
+        self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
-        """Query decisions for a specific session."""
+        """Query decisions for a specific session.
+
+        Ordered by timestamp DESC with `id` as a tiebreaker; paginated like
+        query_sessions.
+        """
         ...
 
     # Metrics operations
@@ -177,9 +191,13 @@ class DatabaseBackend(Protocol):
         ...
 
     async def query_metrics_by_session(
-        self, session_id: str, limit: int = 100
+        self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
-        """Query metrics for a specific session."""
+        """Query metrics for a specific session.
+
+        Ordered by timestamp DESC with `id` as a tiebreaker; paginated like
+        query_sessions.
+        """
         ...
 
     # Notes operations
@@ -214,8 +232,13 @@ class DatabaseBackend(Protocol):
         session_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
-        """Query agent executions with optional filters."""
+        """Query agent executions with optional filters.
+
+        Ordered by started_at DESC with `id` as a tiebreaker; paginated like
+        query_sessions.
+        """
         ...
 
     async def get_agent_stats(self, time_window_hours: int = 168) -> dict[str, Any]:

--- a/src/persistence/migration.py
+++ b/src/persistence/migration.py
@@ -23,6 +23,7 @@ import argparse
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -44,6 +45,13 @@ class MigrationManager:
         "agent_executions",
         "mcp_sessions",
     )
+
+    # Safety valve. A backend that accepted `offset` but ignored it would make
+    # the pagination loops below spin forever, which is worse than the cap this
+    # change removes. Each scan stops after this many pages and reports the stop
+    # as truncation. At the default batch_size=100 that is 10M rows per scan —
+    # far above any real source, so it never trips on an honest backend.
+    MAX_PAGES: int = 100_000
 
     def __init__(
         self,
@@ -73,27 +81,48 @@ class MigrationManager:
         self.warnings.append(message)
         logger.warning(message)
 
-    async def migrate_all(
-        self, batch_size: int = 100, scan_limit: int = 10000
-    ) -> dict[str, Any]:
+    async def _paginate(
+        self,
+        entity: str,
+        reader: Callable[..., Awaitable[list[dict[str, Any]]]],
+        batch_size: int,
+        *args: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield every row from a paginated reader, oldest page first.
+
+        Loops by `offset` until the source is exhausted, so `batch_size` bounds
+        memory per page and never caps how many rows are produced. All six
+        entities now go through here; issue #57 removed the last reader that
+        could not paginate.
+        """
+        offset = 0
+        for _ in range(self.MAX_PAGES):
+            rows = await reader(*args, limit=batch_size, offset=offset)
+            if not rows:
+                return
+            for row in rows:
+                yield row
+            if len(rows) < batch_size:
+                return
+            offset += batch_size
+
+        self._record_truncation(
+            entity,
+            f"{entity}: pagination stopped after {self.MAX_PAGES} pages of "
+            f"{batch_size} rows without the reader ever returning a short page, "
+            "which means it is ignoring `offset`; the source may not be fully migrated",
+        )
+
+    async def migrate_all(self, batch_size: int = 100) -> dict[str, Any]:
         """Migrate all data from source to target.
 
-        Two distinct concepts, not to be confused:
-
-        - `batch_size` is the page size for the genuinely paginated readers
-          (`query_notes`, `query_mcp_sessions`), which loop by `offset` until
-          exhausted. It bounds memory per page, NOT the total number of rows
-          migrated — pagination continues until the source is exhausted
-          regardless of its value.
-        - `scan_limit` is a hard cap for readers that expose no `offset`
-          (`query_sessions`, `query_decisions_by_category`,
-          `query_decisions_by_session`, `query_metrics_by_session`,
-          `query_agent_executions`). These readers cannot be paginated with
-          the current read interface, so hitting `scan_limit` is real
-          truncation and is reported via `status="partial"` and a warning.
-          Properly paginating them requires adding `offset` support to the
-          read interface in `base.py`, which is deliberately out of scope
-          for this change.
+        `batch_size` is the page size for every reader: each scan loops by
+        `offset` until the source is exhausted, so it bounds memory per page and
+        never caps the total number of rows migrated. There is no scan ceiling —
+        issue #57 added `offset` to the last five readers that lacked it, so the
+        `scan_limit` escape hatch this method used to carry is gone. The only
+        remaining truncation path is the MAX_PAGES safety valve in `_paginate`,
+        which trips only on a backend that ignores `offset`.
         """
         start_time = datetime.now()
 
@@ -102,12 +131,12 @@ class MigrationManager:
         logger.info(f"Target: {type(self.target).__name__}")
 
         # Migrate in dependency order
-        await self._migrate_sessions(batch_size, scan_limit)
-        await self._migrate_decisions(batch_size, scan_limit)
-        await self._migrate_metrics(batch_size, scan_limit)
-        await self._migrate_notes(batch_size, scan_limit)
-        await self._migrate_agent_executions(batch_size, scan_limit)
-        await self._migrate_mcp_sessions(batch_size, scan_limit)
+        await self._migrate_sessions(batch_size)
+        await self._migrate_decisions(batch_size)
+        await self._migrate_metrics(batch_size)
+        await self._migrate_notes(batch_size)
+        await self._migrate_agent_executions(batch_size)
+        await self._migrate_mcp_sessions(batch_size)
 
         duration = (datetime.now() - start_time).total_seconds()
 
@@ -127,19 +156,11 @@ class MigrationManager:
 
         return result
 
-    async def _migrate_sessions(self, batch_size: int, scan_limit: int) -> None:
+    async def _migrate_sessions(self, batch_size: int) -> None:
         """Migrate sessions table."""
         logger.info("Migrating sessions...")
-        sessions = await self.source.query_sessions(limit=scan_limit)
-        if len(sessions) >= scan_limit:
-            self._record_truncation(
-                "sessions",
-                f"sessions: query_sessions returned {len(sessions)} rows at "
-                f"scan_limit={scan_limit}; query_sessions has no offset support, "
-                "so the source may contain more sessions than were migrated",
-            )
 
-        for session in sessions:
+        async for session in self._paginate("sessions", self.source.query_sessions, batch_size):
             try:
                 await self.target.save_session(session)
                 self.stats["sessions"] += 1
@@ -150,7 +171,7 @@ class MigrationManager:
 
         logger.info(f"  Migrated {self.stats['sessions']} sessions")
 
-    async def _migrate_decisions(self, batch_size: int, scan_limit: int) -> None:
+    async def _migrate_decisions(self, batch_size: int) -> None:
         """Migrate decisions table.
 
         Decisions are collected into a dict keyed by id BEFORE saving, so a
@@ -170,38 +191,17 @@ class MigrationManager:
         collected: dict[Any, dict[str, Any]] = {}
 
         for category in categories:
-            decisions = await self.source.query_decisions_by_category(category, limit=scan_limit)
-            if len(decisions) >= scan_limit:
-                self._record_truncation(
-                    "decisions",
-                    f"decisions: category '{category}' returned {len(decisions)} rows "
-                    f"at scan_limit={scan_limit}; source may contain more",
-                )
-            for decision in decisions:
+            async for decision in self._paginate(
+                "decisions", self.source.query_decisions_by_category, batch_size, category
+            ):
                 collected[decision.get("id")] = decision
 
         # Uncategorized decisions: pull all decisions per session and keep
         # only the ones not already collected above.
-        sessions = await self.source.query_sessions(limit=scan_limit)
-        if len(sessions) >= scan_limit:
-            self._record_truncation(
-                "decisions",
-                f"decisions: query_sessions returned {len(sessions)} rows at "
-                f"scan_limit={scan_limit} while scanning for uncategorized decisions; "
-                "source may contain more sessions than were scanned",
-            )
-        for session in sessions:
-            session_decisions = await self.source.query_decisions_by_session(
-                session["id"], limit=scan_limit
-            )
-            if len(session_decisions) >= scan_limit:
-                self._record_truncation(
-                    "decisions",
-                    f"decisions: session {session['id']} returned "
-                    f"{len(session_decisions)} decisions at scan_limit={scan_limit}; "
-                    "source may contain more",
-                )
-            for decision in session_decisions:
+        async for session in self._paginate("decisions", self.source.query_sessions, batch_size):
+            async for decision in self._paginate(
+                "decisions", self.source.query_decisions_by_session, batch_size, session["id"]
+            ):
                 collected.setdefault(decision.get("id"), decision)
 
         for decision in collected.values():
@@ -215,26 +215,14 @@ class MigrationManager:
 
         logger.info(f"  Migrated {self.stats['decisions']} decisions")
 
-    async def _migrate_metrics(self, batch_size: int, scan_limit: int) -> None:
+    async def _migrate_metrics(self, batch_size: int) -> None:
         """Migrate metrics table."""
         logger.info("Migrating metrics...")
 
-        sessions = await self.source.query_sessions(limit=scan_limit)
-        if len(sessions) >= scan_limit:
-            self._record_truncation(
-                "metrics",
-                f"metrics: query_sessions returned {len(sessions)} rows at "
-                f"scan_limit={scan_limit}; source may contain more sessions than were scanned",
-            )
-        for session in sessions:
-            metrics = await self.source.query_metrics_by_session(session["id"], limit=scan_limit)
-            if len(metrics) >= scan_limit:
-                self._record_truncation(
-                    "metrics",
-                    f"metrics: session {session['id']} returned {len(metrics)} metrics "
-                    f"at scan_limit={scan_limit}; source may contain more",
-                )
-            for metric in metrics:
+        async for session in self._paginate("metrics", self.source.query_sessions, batch_size):
+            async for metric in self._paginate(
+                "metrics", self.source.query_metrics_by_session, batch_size, session["id"]
+            ):
                 try:
                     await self.target.save_metrics(metric)
                     self.stats["metrics"] += 1
@@ -243,7 +231,7 @@ class MigrationManager:
 
         logger.info(f"  Migrated {self.stats['metrics']} metrics")
 
-    async def _migrate_notes(self, batch_size: int, scan_limit: int) -> None:
+    async def _migrate_notes(self, batch_size: int) -> None:
         """Migrate notes table.
 
         Paginated full scan via query_notes (not joined to sessions, so
@@ -253,24 +241,12 @@ class MigrationManager:
         """
         logger.info("Migrating notes...")
 
-        offset = 0
-        while True:
-            notes = await self.source.query_notes(limit=batch_size, offset=offset)
-            if not notes:
-                break
-
-            for note in notes:
-                try:
-                    await self.target.save_note(note)
-                    self.stats["notes"] += 1
-                except Exception as e:
-                    self._record_failure(
-                        "notes", f"Failed to migrate note {note.get('id')}: {e}"
-                    )
-
-            if len(notes) < batch_size:
-                break
-            offset += batch_size
+        async for note in self._paginate("notes", self.source.query_notes, batch_size):
+            try:
+                await self.target.save_note(note)
+                self.stats["notes"] += 1
+            except Exception as e:
+                self._record_failure("notes", f"Failed to migrate note {note.get('id')}: {e}")
 
         # notes.id is SERIAL on PostgreSQL; explicit-id inserts (preserving
         # source ids for idempotency) don't advance the sequence. Resync it
@@ -283,18 +259,13 @@ class MigrationManager:
 
         logger.info(f"  Migrated {self.stats['notes']} notes")
 
-    async def _migrate_agent_executions(self, batch_size: int, scan_limit: int) -> None:
+    async def _migrate_agent_executions(self, batch_size: int) -> None:
         """Migrate agent_executions table."""
         logger.info("Migrating agent executions...")
 
-        executions = await self.source.query_agent_executions(limit=scan_limit)
-        if len(executions) >= scan_limit:
-            self._record_truncation(
-                "agent_executions",
-                f"agent_executions: query_agent_executions returned "
-                f"{len(executions)} rows at scan_limit={scan_limit}; source may contain more",
-            )
-        for execution in executions:
+        async for execution in self._paginate(
+            "agent_executions", self.source.query_agent_executions, batch_size
+        ):
             try:
                 await self.target.save_agent_execution(execution)
                 self.stats["agent_executions"] += 1
@@ -306,30 +277,21 @@ class MigrationManager:
 
         logger.info(f"  Migrated {self.stats['agent_executions']} agent executions")
 
-    async def _migrate_mcp_sessions(self, batch_size: int, scan_limit: int) -> None:
+    async def _migrate_mcp_sessions(self, batch_size: int) -> None:
         """Migrate mcp_sessions table via a paginated full scan."""
         logger.info("Migrating MCP sessions...")
 
-        offset = 0
-        while True:
-            mcp_sessions = await self.source.query_mcp_sessions(limit=batch_size, offset=offset)
-            if not mcp_sessions:
-                break
-
-            for mcp_session in mcp_sessions:
-                try:
-                    await self.target.save_mcp_session(mcp_session)
-                    self.stats["mcp_sessions"] += 1
-                except Exception as e:
-                    self._record_failure(
-                        "mcp_sessions",
-                        f"Failed to migrate MCP session "
-                        f"{mcp_session.get('mcp_session_id')}: {e}",
-                    )
-
-            if len(mcp_sessions) < batch_size:
-                break
-            offset += batch_size
+        async for mcp_session in self._paginate(
+            "mcp_sessions", self.source.query_mcp_sessions, batch_size
+        ):
+            try:
+                await self.target.save_mcp_session(mcp_session)
+                self.stats["mcp_sessions"] += 1
+            except Exception as e:
+                self._record_failure(
+                    "mcp_sessions",
+                    f"Failed to migrate MCP session {mcp_session.get('mcp_session_id')}: {e}",
+                )
 
         logger.info(f"  Migrated {self.stats['mcp_sessions']} MCP sessions")
 

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -528,6 +528,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         limit: int = 50,
         project_path: str | None = None,
         status: str | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         """Query sessions with optional filters."""
         pool = self._ensure_connected()
@@ -545,8 +546,11 @@ class PostgreSQLBackend(BaseDatabaseBackend):
             params.append(status)
             param_idx += 1
 
-        query += f" ORDER BY started_at DESC LIMIT ${param_idx}"
+        query += f" ORDER BY started_at DESC, id DESC LIMIT ${param_idx}"
         params.append(limit)
+        param_idx += 1
+        query += f" OFFSET ${param_idx}"
+        params.append(offset)
 
         async with pool.acquire() as conn:
             rows = await conn.fetch(query, *params)
@@ -690,7 +694,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
     @db_retry
     async def query_decisions_by_category(
-        self, category: str, limit: int = 100
+        self, category: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
         """Query decisions by category across sessions."""
         pool = self._ensure_connected()
@@ -702,16 +706,17 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 FROM decisions d
                 JOIN sessions s ON d.session_id = s.id
                 WHERE d.category = $1
-                ORDER BY d.timestamp DESC
-                LIMIT $2
+                ORDER BY d.timestamp DESC, d.id DESC
+                LIMIT $2 OFFSET $3
                 """,
                 category,
                 limit,
+                offset,
             )
             return [self._from_record(row) for row in rows]
 
     async def query_decisions_by_session(
-        self, session_id: str, limit: int = 100
+        self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
         """Query decisions for a specific session."""
         pool = self._ensure_connected()
@@ -721,11 +726,12 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 """
                 SELECT * FROM decisions
                 WHERE session_id = $1
-                ORDER BY timestamp DESC
-                LIMIT $2
+                ORDER BY timestamp DESC, id DESC
+                LIMIT $2 OFFSET $3
                 """,
                 session_id,
                 limit,
+                offset,
             )
             return [self._from_record(row) for row in rows]
 
@@ -779,7 +785,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
             return [self._from_record(row) for row in rows]
 
     async def query_metrics_by_session(
-        self, session_id: str, limit: int = 100
+        self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
         """Query metrics for a specific session."""
         pool = self._ensure_connected()
@@ -789,11 +795,12 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 """
                 SELECT * FROM metrics
                 WHERE session_id = $1
-                ORDER BY timestamp DESC
-                LIMIT $2
+                ORDER BY timestamp DESC, id DESC
+                LIMIT $2 OFFSET $3
                 """,
                 session_id,
                 limit,
+                offset,
             )
             return [self._from_record(row) for row in rows]
 
@@ -1319,6 +1326,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         session_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         """Query agent executions with optional filters."""
         pool = self._ensure_connected()
@@ -1336,8 +1344,11 @@ class PostgreSQLBackend(BaseDatabaseBackend):
             params.append(agent_name)
             param_idx += 1
 
-        query += f" ORDER BY started_at DESC LIMIT ${param_idx}"
+        query += f" ORDER BY started_at DESC, id DESC LIMIT ${param_idx}"
         params.append(limit)
+        param_idx += 1
+        query += f" OFFSET ${param_idx}"
+        params.append(offset)
 
         async with pool.acquire() as conn:
             rows = await conn.fetch(query, *params)

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -466,6 +466,7 @@ class SQLiteBackend(BaseDatabaseBackend):
         limit: int = 50,
         project_path: str | None = None,
         status: str | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         """Query sessions with optional filters."""
         conn = self._ensure_connected()
@@ -480,8 +481,9 @@ class SQLiteBackend(BaseDatabaseBackend):
             query += " AND status = ?"
             params.append(status)
 
-        query += " ORDER BY started_at DESC LIMIT ?"
+        query += " ORDER BY started_at DESC, id DESC LIMIT ? OFFSET ?"
         params.append(limit)
+        params.append(offset)
 
         cursor = await conn.execute(query, params)
         rows = await cursor.fetchall()
@@ -618,7 +620,7 @@ class SQLiteBackend(BaseDatabaseBackend):
         await conn.commit()
 
     async def query_decisions_by_category(
-        self, category: str, limit: int = 100
+        self, category: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
         """Query decisions by category across sessions."""
         conn = self._ensure_connected()
@@ -629,16 +631,16 @@ class SQLiteBackend(BaseDatabaseBackend):
             FROM decisions d
             JOIN sessions s ON d.session_id = s.id
             WHERE d.category = ?
-            ORDER BY d.timestamp DESC
-            LIMIT ?
+            ORDER BY d.timestamp DESC, d.id DESC
+            LIMIT ? OFFSET ?
         """,
-            (category, limit),
+            (category, limit, offset),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
     async def query_decisions_by_session(
-        self, session_id: str, limit: int = 100
+        self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
         """Query decisions for a specific session."""
         conn = self._ensure_connected()
@@ -647,10 +649,10 @@ class SQLiteBackend(BaseDatabaseBackend):
             """
             SELECT * FROM decisions
             WHERE session_id = ?
-            ORDER BY timestamp DESC
-            LIMIT ?
+            ORDER BY timestamp DESC, id DESC
+            LIMIT ? OFFSET ?
         """,
-            (session_id, limit),
+            (session_id, limit, offset),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
@@ -699,7 +701,7 @@ class SQLiteBackend(BaseDatabaseBackend):
         return [dict(row) for row in rows]
 
     async def query_metrics_by_session(
-        self, session_id: str, limit: int = 100
+        self, session_id: str, limit: int = 100, offset: int = 0
     ) -> list[dict[str, Any]]:
         """Query metrics for a specific session."""
         conn = self._ensure_connected()
@@ -708,10 +710,10 @@ class SQLiteBackend(BaseDatabaseBackend):
             """
             SELECT * FROM metrics
             WHERE session_id = ?
-            ORDER BY timestamp DESC
-            LIMIT ?
+            ORDER BY timestamp DESC, id DESC
+            LIMIT ? OFFSET ?
         """,
-            (session_id, limit),
+            (session_id, limit, offset),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
@@ -980,6 +982,7 @@ class SQLiteBackend(BaseDatabaseBackend):
         session_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         """Query agent executions with optional filters."""
         conn = self._ensure_connected()
@@ -994,8 +997,9 @@ class SQLiteBackend(BaseDatabaseBackend):
             query += " AND agent_name = ?"
             params.append(agent_name)
 
-        query += " ORDER BY started_at DESC LIMIT ?"
+        query += " ORDER BY started_at DESC, id DESC LIMIT ? OFFSET ?"
         params.append(limit)
+        params.append(offset)
 
         cursor = await conn.execute(query, params)
         rows = await cursor.fetchall()

--- a/tests/regression/test_issue_50_migrate_all_honest.py
+++ b/tests/regression/test_issue_50_migrate_all_honest.py
@@ -231,9 +231,9 @@ async def test_save_decision_twice_same_id_updates_not_duplicates_sqlite(source)
 async def test_batch_size_does_not_cap_total_records_migrated(source, target, manager):
     """Regression guard: `batch_size` must never act as a hard cap on the
     total number of records migrated. `migrate_all()` with its DEFAULT
-    arguments (batch_size=100, scan_limit=10000) must migrate all 150
-    sessions and all 150 notes seeded here — well above batch_size=100 —
-    with nothing truncated at the much larger scan_limit."""
+    arguments (batch_size=100) must migrate all 150 sessions and all 150
+    notes seeded here — well above batch_size=100 — since there is no
+    longer any scan ceiling to truncate against."""
     total = 150
     for i in range(total):
         sid = f"sess-batch-cap-{i:03d}"

--- a/tests/regression/test_issue_57_reader_offset_pagination.py
+++ b/tests/regression/test_issue_57_reader_offset_pagination.py
@@ -1,0 +1,209 @@
+"""
+Regression tests for issue #57: reader offset pagination.
+
+Covers the headline acceptance criteria:
+- `offset: int = 0` was added as the last parameter of five readers
+  (query_sessions, query_decisions_by_category, query_decisions_by_session,
+  query_metrics_by_session, query_agent_executions) in base.py and both
+  backends, each gaining a stable `id` tiebreaker in its ORDER BY.
+- MigrationManager.migrate_all() no longer takes `scan_limit`; every
+  `_migrate_*` now pages through MigrationManager._paginate() by offset
+  until a short page, so batch_size no longer caps the total migrated.
+- MAX_PAGES is the only remaining truncation path, tripped only by a
+  reader that ignores `offset` and always returns a full page.
+
+Match the house style: in-memory SQLite backend, asyncio_mode = "auto"
+(from pyproject.toml) — no @pytest.mark.asyncio needed. See
+tests/regression/test_issue_50_migrate_all_honest.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from persistence.migration import MigrationManager
+from persistence.sqlite import SQLiteBackend
+from tests.persistence.contract_tests import _agent_execution, _decision, _session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def source():
+    """Source in-memory SQLite backend."""
+    db = SQLiteBackend(db_path=":memory:")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def target():
+    """Target in-memory SQLite backend."""
+    db = SQLiteBackend(db_path=":memory:")
+    await db.initialize()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+def manager(source, target):
+    return MigrationManager(source, target)
+
+
+# ---------------------------------------------------------------------------
+# Helper: drain a backend's offset-paginated query into a flat id list
+# ---------------------------------------------------------------------------
+
+
+async def _collect_all_session_ids(backend, page_size: int = 100) -> list[str]:
+    """Page through backend.query_sessions(limit=page_size, offset=n) until a
+    short page, returning the concatenated list of session ids seen."""
+    ids: list[str] = []
+    offset = 0
+    while True:
+        page = await backend.query_sessions(limit=page_size, offset=offset)
+        if not page:
+            break
+        ids.extend(row["id"] for row in page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Headline: no more scan ceiling on migrate_all
+# ---------------------------------------------------------------------------
+
+
+async def test_sessions_beyond_one_page_are_all_migrated(source, target, manager):
+    """250 sessions > batch_size=100 and there is no longer any scan_limit
+    ceiling — migrate_all() must migrate all of them via offset pagination."""
+    total = 250
+    for i in range(total):
+        await source.save_session(_session(session_id=f"sess-page-{i:04d}"))
+
+    result = await manager.migrate_all(batch_size=100)
+
+    assert result["records_migrated"]["sessions"] == total
+    assert result["status"] == "success"
+
+
+async def test_decisions_beyond_one_page_for_a_single_session_are_all_migrated(
+    source, target, manager
+):
+    """250 decisions on a single session exceed batch_size=100 for the
+    query_decisions_by_session fallback loop used for uncategorized
+    decisions; all must still arrive in the target."""
+    sid = "sess-many-decisions-001"
+    await source.save_session(_session(session_id=sid))
+
+    total = 250
+    for i in range(total):
+        await source.save_decision(_decision(session_id=sid, decision_id=f"dec-{i:04d}"))
+
+    result = await manager.migrate_all(batch_size=100)
+
+    assert result["status"] == "success"
+    assert result["records_migrated"]["decisions"] == total
+    target_decisions = await target.query_decisions_by_session(sid, limit=1000)
+    assert len(target_decisions) == total
+
+
+# ---------------------------------------------------------------------------
+# Backend-level: offset pagination is gap-free and repeat-free
+# ---------------------------------------------------------------------------
+
+
+async def test_query_sessions_offset_paginates_without_gaps_or_repeats(source):
+    """No migration involved: page directly through
+    source.query_sessions(limit=100, offset=n) and confirm the ids collected
+    across pages are exactly the 250 seeded rows with no duplicates."""
+    total = 250
+    for i in range(total):
+        await source.save_session(_session(session_id=f"sess-offset-{i:04d}"))
+
+    ids = await _collect_all_session_ids(source, page_size=100)
+
+    assert len(ids) == total
+    assert len(set(ids)) == total
+
+
+async def test_query_sessions_pagination_is_stable_when_timestamps_collide(source):
+    """The tiebreaker guard. All 250 seeded sessions share one identical
+    started_at value. Without the `, id DESC` secondary sort key added by
+    issue #57, ORDER BY started_at DESC alone gives SQLite no guaranteed
+    order among tied rows across separate LIMIT/OFFSET queries, so paging
+    could skip or repeat rows when timestamps collide. THIS test is the one
+    that fails if the id tiebreaker is removed."""
+    total = 250
+    collision = datetime(2026, 1, 1, tzinfo=UTC)
+    for i in range(total):
+        await source.save_session(
+            _session(session_id=f"sess-collide-{i:04d}", start_time=collision)
+        )
+
+    ids = await _collect_all_session_ids(source, page_size=100)
+
+    assert len(ids) == total
+    assert len(set(ids)) == total
+
+
+# ---------------------------------------------------------------------------
+# Agent executions
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_executions_beyond_one_page_are_all_migrated(source, target, manager):
+    """150 agent_execution rows on one session exceed batch_size=100; all
+    must be migrated via the now-paginated query_agent_executions reader."""
+    sid = "sess-agent-exec-001"
+    await source.save_session(_session(session_id=sid))
+
+    total = 150
+    for i in range(total):
+        await source.save_agent_execution(
+            _agent_execution(session_id=sid, agent_name=f"agent-{i:04d}")
+        )
+
+    result = await manager.migrate_all(batch_size=100)
+
+    assert result["records_migrated"]["agent_executions"] == total
+    target_rows = await target.query_agent_executions(session_id=sid, limit=1000)
+    assert len(target_rows) == total
+
+
+# ---------------------------------------------------------------------------
+# MAX_PAGES safety valve
+# ---------------------------------------------------------------------------
+
+
+async def test_paginate_safety_valve_reports_truncation_instead_of_hanging(manager, monkeypatch):
+    """A reader that ignores `offset` and always returns a full page would
+    make the offset-pagination loop spin forever. MAX_PAGES bounds that: it
+    must terminate, mark manager.truncated True, and record a warning
+    mentioning `offset`, instead of hanging. Locks in that removing
+    scan_limit did not introduce an infinite loop."""
+    monkeypatch.setattr(MigrationManager, "MAX_PAGES", 3)
+
+    async def stub_reader(*args, limit, offset=0):
+        return [{"id": "same-row"} for _ in range(limit)]
+
+    async def _drain():
+        rows = []
+        async for row in manager._paginate("sessions", stub_reader, 2):
+            rows.append(row)
+        return rows
+
+    rows = await asyncio.wait_for(_drain(), timeout=5)
+
+    assert len(rows) == 6  # MAX_PAGES(3) * batch_size(2)
+    assert manager.truncated is True
+    assert any("offset" in w for w in manager.warnings)


### PR DESCRIPTION
Closes #57. Finishes the unfinished half of defect #4 in #50.

## What changed

`offset: int = 0` added to the five readers that had none, in `base.py` and both backends:
`query_sessions`, `query_decisions_by_category`, `query_decisions_by_session`, `query_metrics_by_session`, `query_agent_executions`.

Every `_migrate_*` now loops through a new `MigrationManager._paginate()` helper instead of issuing one capped query. `scan_limit` is removed — `batch_size` is now purely a page size, never a ceiling.

## Two decisions worth reviewing

**1. Every widened `ORDER BY` gained an `id` tiebreaker** (`started_at DESC, id DESC` / `timestamp DESC, id DESC`).

This is not cosmetic. Offset paging over a non-unique sort key can skip or repeat rows sharing a timestamp, so paginating *without* a tiebreaker would silently lose data — the same class of bug this PR exists to remove. All four tables were verified to have an `id` column. `test_query_sessions_pagination_is_stable_when_timestamps_collide` seeds 250 rows with one identical `started_at` and is the test that fails if the tiebreaker is dropped.

**2. `MAX_PAGES = 100_000` bounds each scan, so the truncation machinery stays alive.**

The issue suggested removing `scan_limit` "once nothing needs a ceiling". Removing it outright introduces a worse failure than the one it removes: a backend that accepts `offset` but ignores it returns a full page forever and hangs the migration indefinitely. `MAX_PAGES` terminates that case and reports it through the existing `_record_truncation` / `status="partial"` path, so `self.truncated` remains meaningful instead of becoming dead code. At the default `batch_size=100` the bound is 10M rows per scan — far above any real source.

`offset` is the last parameter everywhere, so existing positional callers are unaffected.

## Tests

Six new regression tests in `tests/regression/test_issue_57_reader_offset_pagination.py`:

| Test | Locks in |
|---|---|
| `test_sessions_beyond_one_page_are_all_migrated` | 250 sessions at `batch_size=100`, no ceiling |
| `test_decisions_beyond_one_page_for_a_single_session_are_all_migrated` | the uncategorized-decision fallback loop paginates |
| `test_agent_executions_beyond_one_page_are_all_migrated` | 150 rows through the newly paginated reader |
| `test_query_sessions_offset_paginates_without_gaps_or_repeats` | backend-level: gap-free and repeat-free |
| `test_query_sessions_pagination_is_stable_when_timestamps_collide` | the `id` tiebreaker |
| `test_paginate_safety_valve_reports_truncation_instead_of_hanging` | `MAX_PAGES` terminates rather than spinning |

`test_batch_size_does_not_cap_total_records_migrated` from #50 still passes unchanged — only its docstring was reworded, since there is no longer a scan ceiling to truncate against. Its assertions are byte-identical.

Full suite locally: **479 passed, 74 skipped, 0 failed**. The 74 skips are PostgreSQL-gated and unchanged from before this branch; CI's Test+PG job exercises the Postgres paths.

## Caught during review

The first pass silently missed `SQLiteBackend.query_agent_executions`, which surfaced as 17 failures across three test files — all one `TypeError`, because `_migrate_agent_executions` runs unconditionally inside `migrate_all`. Fixed, then all ten reader/backend combinations were re-audited individually rather than trusted.

## Known residual, not fixed here

`query_decisions_by_category` INNER JOINs `sessions`, so a decision whose session row is missing **and** whose category is outside the hardcoded five-category list is still invisible to the migrator — the same orphan-visibility gap `query_notes` fixed for notes in #55. Out of scope for this change; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)