### PR TITLE
fix(transport): share schema validation across transports and stop masking tool failures (refs #61)

### DIFF
--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -1396,31 +1396,90 @@ class LeanMCPInterface:
 
         return result
 
+    def validate_tool_parameters(
+        self, tool_name: str, parameters: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """
+        Validate parameters against a tool's declared schema.
+
+        Returns an error envelope when the call must be refused, or None when it
+        is safe to dispatch. Both the stdio meta-tool and the HTTP transport call
+        this, so a mistyped parameter name is rejected identically over either
+        one instead of reaching the engine and raising a raw TypeError.
+
+        Callers are responsible for checking registry membership first; an
+        unregistered tool has no schema to validate against and returns None.
+        Schemas without declared properties are not validated either - there is
+        nothing to check the parameters against.
+        """
+        tool_info = self.tool_registry.get(tool_name)
+        if tool_info is None:
+            return None
+
+        schema = tool_info.get("schema") or {}
+        valid_params = set(schema.get("properties", {}))
+        if not valid_params:
+            return None
+
+        unknown = sorted(set(parameters) - valid_params)
+        missing = sorted(set(schema.get("required", [])) - set(parameters))
+        if not unknown and not missing:
+            return None
+
+        problems = []
+        if unknown:
+            problems.append(f"unexpected parameter(s): {unknown}")
+        if missing:
+            problems.append(f"missing required parameter(s): {missing}")
+        return {
+            "tool": tool_name,
+            "status": "error",
+            "error": (
+                f"Invalid parameters for '{tool_name}' - "
+                f"{'; '.join(problems)}. "
+                f"Valid parameters: {sorted(valid_params)}. "
+                f"Call get_tool_spec('{tool_name}') for the full schema."
+            ),
+        }
+
     def _wrap_tool(self, tool_func):
-        """Wrap tool function with token limiting and error handling."""
+        """
+        Wrap tool function with token limiting.
+
+        Exceptions are logged and re-raised rather than turned into an
+        {"error": ...} result. Both transports catch them at the dispatch
+        boundary and report status="error"; swallowing them here made a failed
+        call surface inside a status="success" envelope (issue #61).
+        """
 
         @wraps(tool_func)
         def wrapper(*args, **kwargs):
             try:
                 result = tool_func(*args, **kwargs)
                 return apply_token_limits(result, tool_func.__name__)
-            except Exception as e:
-                logger.error(f"Error in {tool_func.__name__}: {e}")
-                return {"error": str(e), "tool": tool_func.__name__}
+            except Exception:
+                logger.exception(f"Error in {tool_func.__name__}")
+                raise
 
         return wrapper
 
     def _wrap_async_tool(self, async_tool_func):
-        """Wrap async tool function with token limiting and error handling."""
+        """
+        Wrap async tool function with token limiting.
+
+        Exceptions are logged and re-raised for the same reason as _wrap_tool
+        (issue #61) - the dispatch boundary in each transport turns them into a
+        status="error" envelope.
+        """
 
         @wraps(async_tool_func)
         async def wrapper(*args, **kwargs):
             try:
                 result = await async_tool_func(*args, **kwargs)
                 return apply_token_limits(result, async_tool_func.__name__)
-            except Exception as e:
-                logger.error(f"Error in {async_tool_func.__name__}: {e}")
-                return {"error": str(e), "tool": async_tool_func.__name__}
+            except Exception:
+                logger.exception(f"Error in {async_tool_func.__name__}")
+                raise
 
         return wrapper
 
@@ -1768,31 +1827,11 @@ class LeanMCPInterface:
                     "error": f"parameters must be a mapping, got {type(parameters).__name__}",
                 }
 
-            # Validate parameters against the declared schema before dispatch, so a
-            # mistyped name surfaces as an actionable error instead of a raw TypeError
-            # leaking out of the engine. Schemas without declared properties are not
-            # validated (nothing to check against).
-            schema = tool_info.get("schema") or {}
-            valid_params = set(schema.get("properties", {}))
-            if valid_params:
-                unknown = sorted(set(parameters) - valid_params)
-                missing = sorted(set(schema.get("required", [])) - set(parameters))
-                if unknown or missing:
-                    problems = []
-                    if unknown:
-                        problems.append(f"unexpected parameter(s): {unknown}")
-                    if missing:
-                        problems.append(f"missing required parameter(s): {missing}")
-                    return {
-                        "tool": tool_name,
-                        "status": "error",
-                        "error": (
-                            f"Invalid parameters for '{tool_name}' - "
-                            f"{'; '.join(problems)}. "
-                            f"Valid parameters: {sorted(valid_params)}. "
-                            f"Call get_tool_spec('{tool_name}') for the full schema."
-                        ),
-                    }
+            # Validate against the declared schema before dispatch. Shared with the
+            # HTTP transport so both refuse an invalid call identically (issue #61).
+            validation_error = self.validate_tool_parameters(tool_name, parameters)
+            if validation_error is not None:
+                return validation_error
 
             try:
                 # Execute tool - await if async, call directly if sync

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -763,6 +763,10 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
                     "error": f"Tool '{target}' not found",
                     "available_tools": list(tool_registry.keys()),
                 }
+            elif (
+                validation_error := lean_interface.validate_tool_parameters(target, tool_params)
+            ) is not None:
+                result = validation_error
             else:
                 # Tools that read/write session state - need DB sync
                 session_modifying_tools = {

--- a/tests/engine/test_mcp_tool_dispatch.py
+++ b/tests/engine/test_mcp_tool_dispatch.py
@@ -22,8 +22,15 @@ from persistence.sqlite import SQLiteBackend
 
 
 @pytest.fixture
-async def lean_interface(tmp_path):
-    """Yield a LeanMCPInterface backed by a fresh in-process SQLite database."""
+async def lean_interface(tmp_path, monkeypatch):
+    """Yield a LeanMCPInterface backed by a fresh in-process SQLite database.
+
+    Agent-name validation is disabled (mirrors the `engine` fixture in
+    tests/engine/conftest.py) so tests using synthetic agent names like
+    "test-dispatch-agent" do not depend on real files under
+    ~/.claude/agents/, which is machine-specific and would break in CI.
+    """
+    monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
     db = SQLiteBackend(str(tmp_path / "test.db"))
     await db.initialize()
     engine = SessionIntelligenceEngine(
@@ -34,6 +41,19 @@ async def lean_interface(tmp_path):
     interface = LeanMCPInterface(engine)
     yield interface
     await db.close()
+
+
+def _extract_session_id(create_result: dict) -> str:
+    """Pull session_id out of a session_manage_lifecycle(create) response.
+
+    The 'result' payload may be a Pydantic model instance or a plain dict
+    depending on dispatch path, so handle both (same pattern used by
+    test_execute_session_manage_lifecycle_create below).
+    """
+    inner = create_result["result"]
+    if hasattr(inner, "session_id"):
+        return inner.session_id
+    return inner.get("session_id") or inner.get("result", {}).get("session_id")
 
 
 # ---------------------------------------------------------------------------
@@ -220,9 +240,15 @@ class TestExecuteSessionTrackExecution:
     async def test_execute_session_track_execution(self, lean_interface):
         """session_track_execution succeeds with minimal params."""
         execute = _get_meta_tool(lean_interface, "execute_tool")
+        create_result = await execute("session_manage_lifecycle", {"operation": "create"})
+        session_id = _extract_session_id(create_result)
         result = await execute(
             "session_track_execution",
-            {"agent_name": "test-agent", "step_data": {"phase": "start"}},
+            {
+                "session_id": session_id,
+                "agent_name": "test-agent",
+                "step_data": {"phase": "start"},
+            },
         )
         assert result["status"] == "success"
 
@@ -231,9 +257,11 @@ class TestExecuteSessionCoordinateAgents:
     async def test_execute_session_coordinate_agents(self, lean_interface):
         """session_coordinate_agents succeeds with a minimal agents list."""
         execute = _get_meta_tool(lean_interface, "execute_tool")
+        create_result = await execute("session_manage_lifecycle", {"operation": "create"})
+        session_id = _extract_session_id(create_result)
         result = await execute(
             "session_coordinate_agents",
-            {"agents": [{"name": "agent-a"}]},
+            {"session_id": session_id, "agents": [{"name": "agent-a"}]},
         )
         assert result["status"] == "success"
 
@@ -244,7 +272,7 @@ class TestExecuteSessionLogDecision:
         execute = _get_meta_tool(lean_interface, "execute_tool")
         result = await execute(
             "session_log_decision",
-            {"decision": "Use pytest for all new tests"},
+            {"decision": "Use pytest for all new tests", "project_name": "test-project"},
         )
         assert result["status"] == "success"
 
@@ -277,6 +305,12 @@ class TestExecuteSessionMonitorHealth:
 
 
 class TestExecuteSessionOrchestrateWorkflow:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="session_orchestrate_workflow is a placeholder that builds an invalid "
+               "WorkflowState; registered but non-functional. Tracked separately - see "
+               "issue #64 in the PR body.",
+    )
     async def test_execute_session_orchestrate_workflow(self, lean_interface):
         """session_orchestrate_workflow succeeds with a valid workflow_type."""
         execute = _get_meta_tool(lean_interface, "execute_tool")
@@ -313,9 +347,9 @@ class TestExecuteSessionGetDashboard:
 
 class TestExecuteSessionCreateNotebook:
     async def test_execute_session_create_notebook(self, lean_interface):
-        """session_create_notebook succeeds with no required params."""
+        """session_create_notebook succeeds when bound to a project_name."""
         execute = _get_meta_tool(lean_interface, "execute_tool")
-        result = await execute("session_create_notebook", {})
+        result = await execute("session_create_notebook", {"project_name": "test-project"})
         assert result["status"] == "success"
 
 
@@ -352,6 +386,7 @@ class TestExecuteSessionLogLearning:
             {
                 "category": "pattern",
                 "learning_content": "Always use fixtures for shared test data.",
+                "project_name": "test-project",
             },
         )
         assert result["status"] == "success"

--- a/tests/integration/test_error_paths.py
+++ b/tests/integration/test_error_paths.py
@@ -2,8 +2,10 @@
 Integration tests for error handling across layers.
 
 Uses LeanMCPInterface + real SQLite backend (no live server).
-The lean wrappers (_wrap_tool, _wrap_async_tool) catch exceptions and
-return error dicts rather than re-raising — tests verify that behavior.
+The lean wrappers (_wrap_tool, _wrap_async_tool) log exceptions and
+re-raise them (issue #61); the transports' dispatch boundary is what
+converts a raised exception into a status="error" envelope — tests
+verify that behavior.
 
 asyncio_mode = "auto" — no @pytest.mark.asyncio decorators needed.
 """
@@ -66,17 +68,16 @@ async def _call(lean: LeanMCPInterface, tool_name: str, **params):
 # ===========================================================================
 # Wrapper error behaviour
 #
-# _wrap_tool / _wrap_async_tool catch exceptions and return {"error": ...}
-# dicts.  Tests here verify that contract rather than expecting re-raises.
+# _wrap_tool / _wrap_async_tool log exceptions and re-raise them (issue #61).
+# Tests here verify that contract: a missing required argument propagates as
+# a raised exception rather than being swallowed into an {"error": ...} dict.
 # ===========================================================================
 
 
-async def test_lifecycle_missing_operation_returns_error_dict(lean):
-    """session_manage_lifecycle with no params returns an error dict (wrapped)."""
-    result = await _call(lean, "session_manage_lifecycle")
-    # Wrapper catches TypeError and returns error dict
-    assert isinstance(result, dict)
-    assert "error" in result
+async def test_lifecycle_missing_operation_raises(lean):
+    """session_manage_lifecycle with no params raises (wrapper re-raises, issue #61)."""
+    with pytest.raises(TypeError):
+        await _call(lean, "session_manage_lifecycle")
 
 
 async def test_lifecycle_invalid_operation_returns_failure(lean):
@@ -91,11 +92,10 @@ async def test_lifecycle_invalid_operation_returns_failure(lean):
     assert has_error or has_message, f"Expected failure indicator in: {result_dict}"
 
 
-async def test_log_decision_missing_decision_returns_error_dict(lean):
-    """session_log_decision with no 'decision' returns an error dict (wrapped)."""
-    result = await _call(lean, "session_log_decision")
-    assert isinstance(result, dict)
-    assert "error" in result
+async def test_log_decision_missing_decision_raises(lean):
+    """session_log_decision with no 'decision' raises (wrapper re-raises, issue #61)."""
+    with pytest.raises(TypeError):
+        await _call(lean, "session_log_decision")
 
 
 async def test_log_decision_empty_string_is_accepted(lean):
@@ -118,18 +118,16 @@ async def test_log_decision_none_context_is_handled(lean):
 # ===========================================================================
 
 
-async def test_agent_register_missing_name_returns_error_dict(lean):
-    """agent_register without agent_name returns an error dict (wrapped)."""
-    result = await _call(lean, "agent_register", agent_type="domain")
-    assert isinstance(result, dict)
-    assert "error" in result
+async def test_agent_register_missing_name_raises(lean):
+    """agent_register without agent_name raises (wrapper re-raises, issue #61)."""
+    with pytest.raises(TypeError):
+        await _call(lean, "agent_register", agent_type="domain")
 
 
-async def test_agent_register_missing_type_returns_error_dict(lean):
-    """agent_register without agent_type returns an error dict (wrapped)."""
-    result = await _call(lean, "agent_register", agent_name="my-agent")
-    assert isinstance(result, dict)
-    assert "error" in result
+async def test_agent_register_missing_type_raises(lean):
+    """agent_register without agent_type raises (wrapper re-raises, issue #61)."""
+    with pytest.raises(TypeError):
+        await _call(lean, "agent_register", agent_name="my-agent")
 
 
 async def test_agent_register_empty_name_is_handled(lean):
@@ -169,18 +167,16 @@ async def test_agent_log_decision_unknown_agent_is_handled(lean):
 # ===========================================================================
 
 
-async def test_track_execution_missing_params_returns_error_dict(lean):
-    """session_track_execution with no params returns an error dict (wrapped)."""
-    result = await _call(lean, "session_track_execution")
-    assert isinstance(result, dict)
-    assert "error" in result
+async def test_track_execution_missing_params_raises(lean):
+    """session_track_execution with no params raises (wrapper re-raises, issue #61)."""
+    with pytest.raises(TypeError):
+        await _call(lean, "session_track_execution")
 
 
-async def test_track_execution_partial_params_returns_error_dict(lean):
-    """session_track_execution with only step_data returns an error dict (wrapped)."""
-    result = await _call(lean, "session_track_execution", step_data={"phase": "start"})
-    assert isinstance(result, dict)
-    assert "error" in result
+async def test_track_execution_partial_params_raises(lean):
+    """session_track_execution with only step_data raises (wrapper re-raises, issue #61)."""
+    with pytest.raises(TypeError):
+        await _call(lean, "session_track_execution", step_data={"phase": "start"})
 
 
 # ===========================================================================

--- a/tests/regression/test_issue_61_transport_validation_parity.py
+++ b/tests/regression/test_issue_61_transport_validation_parity.py
@@ -1,0 +1,403 @@
+"""
+Regression tests for issue #61: an unknown/mistyped parameter passed to
+execute_tool (e.g. `category` on session_log_decision, which has never been
+a declared parameter of that tool's schema) was silently dropped instead of
+refused.
+
+Two independent bugs combined to make this dangerous:
+
+1. Only the stdio meta-tool validated parameters against the declared schema
+   before dispatch. The HTTP transport's `_handle_tool_call` dispatched
+   straight through, so an extra/misspelled kwarg either blew up inside the
+   engine call with a raw TypeError, or in some cases was simply ignored by
+   `**kwargs`-style signatures - callers had no reliable signal that their
+   call was wrong.
+2. `_wrap_tool`/`_wrap_async_tool` caught ALL exceptions raised by a tool
+   implementation and returned an `{"error": ...}` dict as the tool's
+   *result*, which the transport then wrapped in a top-level
+   `status="success"` envelope. A rejected/failed call could report success
+   while writing nothing to the database - the exact shape of the issue #61
+   report.
+
+The fix: `LeanMCPInterface.validate_tool_parameters()` is now a single
+shared pre-dispatch gate called by BOTH the stdio `execute_tool` meta-tool
+and the HTTP transport's `_handle_tool_call`, and `_wrap_tool`/
+`_wrap_async_tool` now log-and-reraise instead of swallowing exceptions, so
+transport-level exception handlers report `status="error"` instead of a
+success envelope with a buried error.
+
+These tests reuse the ASGI harness pattern from
+tests/integration/test_http_transport.py (minimal FastAPI app wired
+directly to SQLite state, bypassing the PostgreSQL lifespan) rather than
+inventing a new one.
+
+asyncio_mode = "auto" - no @pytest.mark.asyncio decorators needed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from core.session_engine import SessionIntelligenceEngine
+from lean_mcp_interface import LeanMCPInterface
+from persistence import DatabaseConfig
+from persistence.sqlite import SQLiteBackend
+from transport.http_server import HTTPSessionIntelligenceServer, NotificationManager
+from transport.mcp_session_manager import MCPSessionManager
+from transport.security import SecurityConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrors tests/integration/test_http_transport.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Initialised SQLite backend."""
+    backend = SQLiteBackend(str(tmp_path / "test_issue_61.db"))
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest.fixture
+async def app(tmp_path, db):
+    """
+    FastAPI app with pre-populated state using SQLite.
+
+    Same construction as tests/integration/test_http_transport.py: create
+    the HTTPSessionIntelligenceServer, call create_app() for routes/
+    middleware, then inject app.state directly (httpx.ASGITransport never
+    fires lifespan events, so this injected state is the only state used).
+    """
+    engine = SessionIntelligenceEngine(
+        repository_path=str(tmp_path),
+        use_filesystem=False,
+        database=db,
+    )
+    lean = LeanMCPInterface(engine)
+    mcp_mgr = MCPSessionManager(db)
+    notif_mgr = NotificationManager()
+
+    sc = SecurityConfig(
+        localhost_only=False,
+        allowed_origins=["*"],
+        require_api_key=False,
+    )
+
+    server = HTTPSessionIntelligenceServer(
+        host="127.0.0.1",
+        port=4099,
+        repository_path=str(tmp_path),
+        db_config=DatabaseConfig(),
+        security_config=sc,
+    )
+    fastapi_app = server.create_app()
+
+    fastapi_app.state.database = db
+    fastapi_app.state.session_engine = engine
+    fastapi_app.state.lean_interface = lean
+    fastapi_app.state.mcp_session_manager = mcp_mgr
+    fastapi_app.state.notification_manager = notif_mgr
+
+    yield fastapi_app
+
+
+@pytest.fixture
+async def asgi_client(app):
+    """AsyncClient wired to the pre-seeded ASGI app."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mcp_body(method: str, params: dict | None = None, req_id: int = 1) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params or {}}
+
+
+async def _initialize_mcp(client: httpx.AsyncClient) -> str:
+    """Run MCP initialize handshake, return the new session ID."""
+    resp = await client.post(
+        "/mcp",
+        json=_mcp_body("initialize", {"clientInfo": {"name": "pytest", "version": "0.0.1"}}),
+    )
+    assert resp.status_code == 200, f"initialize failed: {resp.text}"
+    return resp.headers["MCP-Session-Id"]
+
+
+async def _http_execute_tool(
+    client: httpx.AsyncClient, tool_name: str, parameters: dict
+) -> dict:
+    """Run execute_tool(tool_name, parameters) over the HTTP/MCP transport
+    and return the decoded envelope."""
+    session_id = await _initialize_mcp(client)
+    resp = await client.post(
+        "/mcp",
+        headers={"MCP-Session-Id": session_id},
+        json=_mcp_body(
+            "tools/call",
+            {
+                "name": "execute_tool",
+                "arguments": {"tool_name": tool_name, "parameters": parameters},
+            },
+        ),
+    )
+    assert resp.status_code == 200, f"tools/call failed: {resp.text}"
+    return json.loads(resp.json()["result"]["content"][0]["text"])
+
+
+def _get_meta_tool(interface: LeanMCPInterface, name: str):
+    """Return the callable registered as a FastMCP tool by name."""
+    # FastMCP stores tools in ._tool_manager._tools (dict keyed by name).
+    # We access the underlying fn to call it directly in tests.
+    manager = interface.app._tool_manager
+    tool_obj = manager._tools[name]
+    return tool_obj.fn
+
+
+async def _stdio_execute_tool(
+    interface: LeanMCPInterface, tool_name: str, parameters: dict
+) -> dict:
+    """Run execute_tool(tool_name, parameters) over the stdio meta-tool path."""
+    execute = _get_meta_tool(interface, "execute_tool")
+    return await execute(tool_name, parameters)
+
+
+async def _count_decision_rows(db: SQLiteBackend) -> int:
+    cursor = await db._connection.execute("SELECT COUNT(*) FROM decisions")
+    row = await cursor.fetchone()
+    return row[0]
+
+
+# ===========================================================================
+# TEST 1: verbatim repro from issue #61 (acceptance criterion)
+# ===========================================================================
+
+
+async def test_unknown_parameter_over_http_is_refused_and_writes_no_row(
+    asgi_client, db, tmp_path
+):
+    """
+    Verbatim repro of issue #61: session_log_decision does not declare a
+    `category` parameter, yet a caller could pass one over HTTP and receive
+    a status="success" envelope while the decision was never written -
+    the extra kwarg either raised inside the engine or was dropped, and
+    the exception-swallowing in _wrap_async_tool hid it either way.
+
+    Asserts the call is now refused up front (status="error" naming the
+    offending parameter) AND, critically, that no decision row is written -
+    this is the actual point of the bug: the old behaviour reported success
+    while persisting nothing.
+    """
+    before = await _count_decision_rows(db)
+
+    # Verbatim repro from issue #61: `category` is not declared in
+    # session_log_decision's schema (see lean_mcp_interface.py registry).
+    payload = await _http_execute_tool(
+        asgi_client,
+        "session_log_decision",
+        {
+            "decision": "Use PostgreSQL for production",
+            "context": {"reason": "scale"},
+            "category": "architecture",
+            "project_path": str(tmp_path),
+        },
+    )
+
+    assert payload["status"] == "error"
+    assert "category" in payload["error"]
+    assert "unexpected" in payload["error"].lower()
+
+    after = await _count_decision_rows(db)
+    assert after == before, (
+        "no decision row should have been written for a refused call; "
+        f"before={before} after={after}"
+    )
+
+
+# ===========================================================================
+# TEST 2: identical rejection over both transports (acceptance criterion)
+# ===========================================================================
+
+
+async def test_unknown_parameter_is_refused_identically_over_both_transports(
+    app, asgi_client, tmp_path
+):
+    """
+    The same invalid call, run through both the stdio meta-tool path and
+    the HTTP transport against the SAME engine/registry, must produce not
+    just the same status but the exact same error STRING. Equal strings
+    prove the two transports share one validation implementation
+    (validate_tool_parameters) rather than two independently-written
+    checks that happen to agree today and could silently diverge later.
+    """
+    lean_interface = app.state.lean_interface
+    parameters = {
+        "decision": "Use PostgreSQL for production",
+        "category": "architecture",
+        "project_path": str(tmp_path),
+    }
+
+    stdio_result = await _stdio_execute_tool(
+        lean_interface, "session_log_decision", parameters
+    )
+    http_result = await _http_execute_tool(
+        asgi_client, "session_log_decision", parameters
+    )
+
+    assert stdio_result["status"] == "error"
+    assert http_result["status"] == "error"
+    assert stdio_result["error"] == http_result["error"]
+
+
+# ===========================================================================
+# TEST 3: divergence guard matrix (acceptance criterion)
+# ===========================================================================
+#
+# Tool names below are taken directly from the registry built in
+# src/lean_mcp_interface.py:
+#   - session_manage_lifecycle: required=["operation"], several optional
+#     params (mode, project_name, metadata, auto_recovery)
+#   - session_analyze_patterns: no required params at all (scope,
+#     pattern_types, include_agents, learning_mode, generate_insights are
+#     all optional)
+
+TRANSPORT_PARITY_CASES = [
+    pytest.param(
+        "session_manage_lifecycle",
+        {"operation": "create", "bogus_param": "x"},
+        id="unknown-param-on-tool-with-required-params",
+    ),
+    pytest.param(
+        "session_analyze_patterns",
+        {"bogus_param": "x"},
+        id="unknown-param-on-tool-with-only-optional-params",
+    ),
+    pytest.param(
+        "session_manage_lifecycle",
+        {},
+        id="missing-required-param",
+    ),
+    pytest.param(
+        "session_manage_lifecycle",
+        {"operation": "create", "foo": 1, "bar": 2},
+        id="multiple-unknown-params-at-once",
+    ),
+    pytest.param(
+        "session_manage_lifecycle",
+        {"foo": 1},
+        id="unknown-and-missing-together",
+    ),
+]
+
+
+@pytest.mark.parametrize("tool_name,parameters", TRANSPORT_PARITY_CASES)
+async def test_transport_validation_parity_matrix(app, asgi_client, tool_name, parameters):
+    """
+    Divergence guard: for a matrix of invalid-parameter shapes (unknown
+    param on a tool with required params, unknown param on a tool with only
+    optional params, missing required param, multiple unknown params at
+    once, and unknown+missing combined), both transports must produce the
+    identical (status, error) pair. This test must FAIL the moment either
+    transport's dispatch path stops calling validate_tool_parameters, or
+    calls it differently, since that is exactly how #61 happened - the
+    stdio path validated and the HTTP path did not.
+    """
+    lean_interface = app.state.lean_interface
+
+    stdio_result = await _stdio_execute_tool(lean_interface, tool_name, parameters)
+    http_result = await _http_execute_tool(asgi_client, tool_name, parameters)
+
+    stdio_pair = (stdio_result.get("status"), stdio_result.get("error"))
+    http_pair = (http_result.get("status"), http_result.get("error"))
+
+    assert stdio_pair[0] == "error"
+    assert http_pair[0] == "error"
+    assert stdio_pair == http_pair
+
+
+# ===========================================================================
+# TEST 4: an exception inside a tool never reports success over HTTP
+# ===========================================================================
+
+
+async def test_exception_inside_tool_is_not_reported_as_success_over_http(
+    tmp_path, monkeypatch
+):
+    """
+    Guards the second half of #61 independently of parameter validation: if
+    a tool implementation raises AFTER passing the schema-validation gate
+    (i.e. the call itself is well-formed but fails at runtime), the HTTP
+    transport must report status="error" with the exception text, never
+    status="success". Before the fix, _wrap_tool caught the exception and
+    returned {"error": ...} as the tool's *result*, which the HTTP handler
+    then wrapped in status="success".
+
+    The engine method is patched BEFORE constructing LeanMCPInterface:
+    the tool registry captures a direct reference to the bound method at
+    construction time (`self._wrap_tool(self.session_engine.<method>)`), so
+    patching the engine instance afterwards would not reach an
+    already-built registry entry.
+    """
+    backend = SQLiteBackend(str(tmp_path / "test_issue_61_boom.db"))
+    await backend.initialize()
+    try:
+        engine = SessionIntelligenceEngine(
+            repository_path=str(tmp_path),
+            use_filesystem=False,
+            database=backend,
+        )
+
+        def _boom(**kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(engine, "session_analyze_patterns", _boom)
+
+        lean = LeanMCPInterface(engine)
+        mcp_mgr = MCPSessionManager(backend)
+        notif_mgr = NotificationManager()
+        sc = SecurityConfig(
+            localhost_only=False, allowed_origins=["*"], require_api_key=False
+        )
+
+        server = HTTPSessionIntelligenceServer(
+            host="127.0.0.1",
+            port=4099,
+            repository_path=str(tmp_path),
+            db_config=DatabaseConfig(),
+            security_config=sc,
+        )
+        fastapi_app = server.create_app()
+        fastapi_app.state.database = backend
+        fastapi_app.state.session_engine = engine
+        fastapi_app.state.lean_interface = lean
+        fastapi_app.state.mcp_session_manager = mcp_mgr
+        fastapi_app.state.notification_manager = notif_mgr
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=fastapi_app),
+            base_url="http://testserver",
+        ) as client:
+            # Schema-valid parameters: "scope" is a declared, optional
+            # property of session_analyze_patterns, so this call must clear
+            # validate_tool_parameters and actually reach the (patched)
+            # engine method.
+            payload = await _http_execute_tool(
+                client, "session_analyze_patterns", {"scope": "recent"}
+            )
+    finally:
+        await backend.close()
+
+    assert payload["status"] == "error"
+    assert payload["status"] != "success"
+    assert "boom" in payload["error"]


### PR DESCRIPTION
Fixes the two separable problems in #61.

## 1. Validation now lives in one place

The stdio meta-tool validated parameters against the declared schema before dispatch; `http_server.py` went straight from registry lookup to `tool_func(**tool_params)`. Since the systemd unit runs `pixi run http-server`, MCP clients used the unvalidated path — the schema was an enforced contract over stdio and documentation over HTTP.

Extracted the gate into `LeanMCPInterface.validate_tool_parameters()`. The stdio path's inline block became a four-line call to it; the HTTP path gained it as an `elif` between the not-found check and the dispatch block, so a refused call never reaches the engine, `_ensure_sessions_loaded_from_database`, or `_persist_sessions_to_database`.

Both transports already shared one `LeanMCPInterface` instance (`http_server.py:206,714`), so this is genuinely one implementation rather than two kept in sync.

## 2. A `TypeError` no longer reports as `status: "success"`

Root cause was not the envelope code — both transports already wrap dispatch in a `try/except` that yields `status="error"`. It could never fire, because `_wrap_tool`/`_wrap_async_tool` caught every exception and *returned* `{"error": str(e), "tool": ...}` as the result. All 33 registry entries route through those wrappers.

They now log and re-raise.

### This changes a documented contract

`tests/integration/test_error_paths.py` explicitly documented and asserted the swallow behaviour ("catch exceptions and return error dicts rather than re-raising — tests verify that behavior"). It now asserts the re-raise contract. Called out explicitly because it is a contract change, not just an added check — though the behaviour it pinned is precisely what #61 identifies as the bug, and those tests bypass dispatch entirely by calling implementations straight from the registry.

### What it unmasked

Ten tests in `test_mcp_tool_dispatch.py` had been passing **vacuously** — asserting `status == "success"` on calls that were failing all along, with the failure swallowed before it could reach the assertion.

- **Nine were fixture gaps**: missing session context, or invented agent names that don't exist under `~/.claude/agents`. Now given valid inputs. The agent-registry ones use the `SESSION_INTELLIGENCE_AGENT_VALIDATION=off` pattern already established in `tests/engine/conftest.py`, rather than depending on machine-local agent directories.
- **One found a real defect**: `session_orchestrate_workflow` hardcodes `WorkflowState(state_machine={})` while `StateMachine.current_state` has no default, so the registered tool raises `ValidationError` on *every* call. Filed as **#64** and marked `xfail(strict=True)` — not fixed here, since choosing between making the placeholder valid, implementing it, and unregistering it is a product decision. `strict=True` means the marker fails loudly the moment the engine is fixed.

No assertion was weakened to make anything pass.

## Regression tests

Against the issue's acceptance criteria:

| Criterion | Test |
|---|---|
| verbatim repro refused, **and no row written** | `test_unknown_parameter_over_http_is_refused_and_writes_no_row` — counts rows in `decisions` directly before/after |
| unknown param rejected identically over both transports | `test_unknown_parameter_is_refused_identically_over_both_transports` — asserts the error **strings** are equal, not just the statuses |
| fails if the transports diverge again | `test_transport_validation_parity_matrix` — five invalid-parameter shapes, identical `(status, error)` pair required from both |
| exception never yields success over HTTP | `test_exception_inside_tool_is_not_reported_as_success_over_http` |

**All eight items were verified to fail against the pre-fix tree at `845bdd7`**, each with `assert 'success' == 'error'`. In the cross-transport test the stdio side returned `error` while HTTP returned `success` — the divergence reproduced directly. A regression test that passes both before and after guards nothing, so this was checked rather than assumed.

## Suite

`487 passed, 74 skipped, 1 xfailed, 0 failed`. The 74 skips are pre-existing PostgreSQL tests needing a live connection; the xfail is #64.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)