### PR TITLE
fix(engine): key notebook lookup on project_name, not raw path equality (refs #62)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -2583,6 +2583,7 @@ class SessionIntelligenceEngine:
     async def session_query_notebooks(
         self,
         project_path: str | None = None,
+        project_name: str | None = None,
         tags: list[str] | None = None,
         limit: int = 20,
     ) -> list[dict[str, Any]]:
@@ -2590,12 +2591,24 @@ class SessionIntelligenceEngine:
         Query session notebooks/summaries with optional filters.
 
         Args:
-            project_path: Filter by project path
+            project_path: Project path filter, accepted for convenience and
+                resolved to a project_name (issue #62: the old implementation
+                compared project_path with raw SQL string equality against
+                s.project_path -- a trailing slash, an unresolved symlink, or
+                a session created from a subdirectory would silently return
+                zero rows instead of erroring). Ignored if project_name is
+                also given.
+            project_name: Filter by project name. This is what rows are
+                actually keyed on elsewhere in this module (see
+                session_recall) and is the preferred filter.
             tags: Filter by tags
             limit: Maximum results to return
 
         Returns:
-            List of session notebook summaries
+            List of session notebook summaries. If project_path is supplied
+            but cannot be bound to a usable project_name, returns an empty
+            list (with a logged warning) rather than silently falling back
+            to an unfiltered query across every project's notebooks.
         """
         if not self.database:
             debug_logger.warning(
@@ -2603,9 +2616,45 @@ class SessionIntelligenceEngine:
             )
             return []
 
+        effective_project_name = project_name
+
+        # No explicit project_name: try to derive one from project_path.
+        # Mirrors the guard in session_log_decision/session_log_learning
+        # (see ~line 1302 and ~line 2754): reject a relative project_path
+        # because derive_project_name() resolves it against the SERVER's
+        # cwd, not the caller's, and discard a derived UNBOUND result
+        # rather than using it, to avoid recreating the invisible-rows bug
+        # #48 fixed. Unlike those write paths, an unusable project_path
+        # here must NOT fall back to an unfiltered query -- that would
+        # silently return every project's notebooks for a call the caller
+        # explicitly scoped to one project.
+        if not effective_project_name and project_path:
+            if (
+                project_path != UNKNOWN_PROJECT_PATH
+                and Path(project_path).is_absolute()
+            ):
+                derived_name = derive_project_name(project_path)
+                if derived_name != UNBOUND:
+                    effective_project_name = derived_name
+                else:
+                    debug_logger.warning(
+                        f"session_query_notebooks: project_path "
+                        f"{project_path!r} could not be bound to a project "
+                        "name; returning no results instead of querying "
+                        "unscoped"
+                    )
+                    return []
+            else:
+                debug_logger.warning(
+                    f"session_query_notebooks: project_path {project_path!r} "
+                    "is not usable (relative path or unknown sentinel); "
+                    "returning no results instead of querying unscoped"
+                )
+                return []
+
         try:
             results = await self.database.query_session_summaries(
-                project_path=project_path,
+                project_name=effective_project_name,
                 tags=tags,
                 limit=limit,
             )

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -610,7 +610,20 @@ class LeanMCPInterface:
                 "properties": {
                     "project_path": {
                         "type": "string",
-                        "description": "Filter notebooks by project path",
+                        "description": (
+                            "Filter notebooks by project path. Accepted for "
+                            "convenience and resolved to a project_name "
+                            "internally; prefer project_name directly when "
+                            "known, since path equality is fragile (trailing "
+                            "slashes, symlinks, subdirectories)."
+                        ),
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "description": (
+                            "Filter notebooks by project name (preferred over "
+                            "project_path). Takes priority if both are given."
+                        ),
                     },
                     "tags": {
                         "type": "array",
@@ -627,6 +640,7 @@ class LeanMCPInterface:
             "examples": [
                 {"limit": 10},
                 {"project_path": "/home/user/my-project", "limit": 5},
+                {"project_name": "session-intelligence", "limit": 5},
                 {"tags": ["feature", "bugfix"]},
             ],
         }

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -1020,7 +1020,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
     async def query_session_summaries(
         self,
-        project_path: str | None = None,
+        project_name: str | None = None,
         tags: list[str] | None = None,
         limit: int = 20,
     ) -> list[dict[str, Any]]:
@@ -1030,16 +1030,16 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         async with pool.acquire() as conn:
             if tags:
                 # Query by tags using JSONB containment
-                if project_path:
+                if project_name:
                     query = """
                         SELECT ss.*, s.project_path, s.project_name
                         FROM session_summaries ss
                         JOIN sessions s ON ss.session_id = s.id
-                        WHERE ss.tags @> $1::jsonb AND s.project_path = $2
+                        WHERE ss.tags @> $1::jsonb AND s.project_name = $2
                         ORDER BY ss.created_at DESC
                         LIMIT $3
                     """
-                    rows = await conn.fetch(query, json.dumps([tags[0]]), project_path, limit)
+                    rows = await conn.fetch(query, json.dumps([tags[0]]), project_name, limit)
                 else:
                     query = """
                         SELECT ss.*, s.project_path, s.project_name
@@ -1050,17 +1050,17 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                         LIMIT $2
                     """
                     rows = await conn.fetch(query, json.dumps([tags[0]]), limit)
-            elif project_path:
+            elif project_name:
                 # Query by project
                 query = """
                     SELECT ss.*, s.project_path, s.project_name
                     FROM session_summaries ss
                     JOIN sessions s ON ss.session_id = s.id
-                    WHERE s.project_path = $1
+                    WHERE s.project_name = $1
                     ORDER BY ss.created_at DESC
                     LIMIT $2
                 """
-                rows = await conn.fetch(query, project_path, limit)
+                rows = await conn.fetch(query, project_name, limit)
             else:
                 # Query all recent
                 query = """

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -873,7 +873,7 @@ class SQLiteBackend(BaseDatabaseBackend):
 
     async def query_session_summaries(
         self,
-        project_path: str | None = None,
+        project_name: str | None = None,
         tags: list[str] | None = None,
         limit: int = 20,
     ) -> list[dict[str, Any]]:
@@ -891,22 +891,22 @@ class SQLiteBackend(BaseDatabaseBackend):
                 )
             """
             params: list[Any] = [tags[0]]  # Match first tag
-            if project_path:
-                query += " AND s.project_path = ?"
-                params.append(project_path)
+            if project_name:
+                query += " AND s.project_name = ?"
+                params.append(project_name)
             query += " ORDER BY ss.created_at DESC LIMIT ?"
             params.append(limit)
-        elif project_path:
+        elif project_name:
             # Query by project
             query = """
                 SELECT ss.*, s.project_path, s.project_name
                 FROM session_summaries ss
                 JOIN sessions s ON ss.session_id = s.id
-                WHERE s.project_path = ?
+                WHERE s.project_name = ?
                 ORDER BY ss.created_at DESC
                 LIMIT ?
             """
-            params = [project_path, limit]
+            params = [project_name, limit]
         else:
             # Query all recent
             query = """

--- a/tests/regression/test_issue_62_notebook_project_binding.py
+++ b/tests/regression/test_issue_62_notebook_project_binding.py
@@ -1,0 +1,186 @@
+"""
+Regression tests for issue #62: session_query_notebooks used to forward
+project_path into a raw SQL equality match (WHERE s.project_path = ?), so a
+legitimate path that merely differed in spelling (a trailing slash, an
+unresolved symlink, a subdirectory checkout) returned ZERO rows instead of
+the caller's notebooks.
+
+The fix resolves project_path to a project_name via derive_project_name()
+and matches on s.project_name (see persistence.sqlite.query_session_summaries
+and the guard at the top of core.session_engine.session_query_notebooks,
+~line 2583), and also accepts project_name directly as a first-class filter.
+
+These tests seed real session + session_summary rows through the SQLite
+backend (there is no shortcut: session_query_notebooks joins session_summaries
+against sessions on session_id and filters on s.project_name), then exercise
+session_query_notebooks under four scenarios: a differently-spelled path (the
+verbatim #62 symptom), the new project_name parameter, an unusable path that
+must not silently widen to every project, and the no-filter back-compat path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from core.project_naming import derive_project_name
+from core.session_engine import UNKNOWN_PROJECT_PATH, SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine(tmp_path):
+    """SessionIntelligenceEngine backed by a fresh in-process SQLite database."""
+    db = SQLiteBackend(str(tmp_path / "test.db"))
+    await db.initialize()
+    eng = SessionIntelligenceEngine(
+        repository_path=str(tmp_path),
+        use_filesystem=False,
+        database=db,
+    )
+    yield eng
+    await db.close()
+
+
+async def _seed_notebook(engine: SessionIntelligenceEngine, project_path: str, title: str):
+    """Create a session bound to project_path, plus a notebook/summary for it.
+
+    session_query_notebooks filters on s.project_name (joined from sessions),
+    so both a sessions row and a session_summaries row are required for
+    there to be anything to find.
+    """
+    session_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    project_name = derive_project_name(project_path)
+
+    await engine.database.save_session(
+        {
+            "id": session_id,
+            "started_at": now,
+            "project_path": project_path,
+            "project_name": project_name,
+        }
+    )
+    await engine.database.save_session_summary(
+        {
+            "session_id": session_id,
+            "title": title,
+            "summary_markdown": f"# {title}",
+            "key_changes": [],
+            "tags": [],
+            "created_at": now,
+        }
+    )
+    return session_id, project_name
+
+
+# ---------------------------------------------------------------------------
+# Test 1: the core regression guard -- differently-spelled path must resolve
+# ---------------------------------------------------------------------------
+
+
+async def test_notebooks_found_when_queried_path_spelling_differs(engine, tmp_path):
+    """
+    Pre-fix, session_query_notebooks compared project_path with raw SQL
+    string equality against s.project_path. A trailing slash on an otherwise
+    identical, legitimate path returned zero rows -- this is the verbatim
+    symptom reported in #62.
+    """
+    project_path = str(tmp_path)
+    session_id, _project_name = await _seed_notebook(engine, project_path, "Notebook A")
+
+    queried_path = project_path + "/"
+    assert queried_path != project_path, "test setup requires a differing spelling"
+
+    results = await engine.session_query_notebooks(project_path=queried_path)
+
+    session_ids = {r["session_id"] for r in results}
+    assert session_id in session_ids, (
+        f"expected notebook for session {session_id} when querying with "
+        f"differently-spelled path {queried_path!r}; got {results!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: the new project_name parameter
+# ---------------------------------------------------------------------------
+
+
+async def test_notebooks_found_when_queried_by_project_name(engine, tmp_path):
+    """project_name must work as a first-class filter, independent of project_path."""
+    project_path = str(tmp_path)
+    session_id, project_name = await _seed_notebook(engine, project_path, "Notebook B")
+
+    results = await engine.session_query_notebooks(project_name=project_name)
+
+    session_ids = {r["session_id"] for r in results}
+    assert session_id in session_ids, (
+        f"expected notebook for session {session_id} when querying by "
+        f"project_name={project_name!r}; got {results!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: an unusable project_path must yield empty, never every project
+# ---------------------------------------------------------------------------
+
+
+async def test_unusable_project_path_returns_empty_not_every_project(engine, tmp_path):
+    """
+    An unusable project_path filter (a relative path, or the _unknown_
+    sentinel) must return an empty list -- never silently widen to an
+    unfiltered query returning every project's notebooks. This pins the
+    deliberate design choice documented in session_query_notebooks: unlike
+    the write-path guards it mirrors, a bad filter here must not fall back
+    to "return everything".
+    """
+    proj_a = tmp_path / "proj_a"
+    proj_b = tmp_path / "proj_b"
+    proj_a.mkdir()
+    proj_b.mkdir()
+
+    session_a, _ = await _seed_notebook(engine, str(proj_a), "Notebook A")
+    session_b, _ = await _seed_notebook(engine, str(proj_b), "Notebook B")
+
+    for unusable_path in ("some/relative/dir", UNKNOWN_PROJECT_PATH):
+        results = await engine.session_query_notebooks(project_path=unusable_path)
+
+        session_ids = {r["session_id"] for r in results}
+        assert results == [], (
+            f"expected empty result for unusable project_path {unusable_path!r}, "
+            f"got {results!r}"
+        )
+        assert session_a not in session_ids, (
+            f"project_path={unusable_path!r} leaked proj_a's notebook"
+        )
+        assert session_b not in session_ids, (
+            f"project_path={unusable_path!r} leaked proj_b's notebook"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: no filter still returns every project's notebooks (back-compat)
+# ---------------------------------------------------------------------------
+
+
+async def test_no_project_filter_still_returns_all_notebooks(engine, tmp_path):
+    """With no project_path and no project_name, the unfiltered path must still work."""
+    proj_a = tmp_path / "proj_a"
+    proj_b = tmp_path / "proj_b"
+    proj_a.mkdir()
+    proj_b.mkdir()
+
+    session_a, _ = await _seed_notebook(engine, str(proj_a), "Notebook A")
+    session_b, _ = await _seed_notebook(engine, str(proj_b), "Notebook B")
+
+    results = await engine.session_query_notebooks()
+
+    session_ids = {r["session_id"] for r in results}
+    assert session_a in session_ids, f"expected proj_a's notebook, got {results!r}"
+    assert session_b in session_ids, f"expected proj_b's notebook, got {results!r}"


### PR DESCRIPTION
Fixes #62.

## The bug

`session_query_notebooks` forwarded a caller-supplied `project_path` into `query_session_summaries`, which compared it with raw SQL string equality (`WHERE s.project_path = ?`). Any difference in spelling — trailing slash, unresolved symlink, a session created from a subdirectory — returned zero rows. It returned *empty rather than erroring*, so it read as "this project has no notebooks" instead of "the lookup did not match."

## The fix, and why not normalization

Re-keyed the lookup on `project_name`, which is the convention this repo already uses: `session_recall` matches on it (`postgresql.py:1167`), and `session_log_decision`/`session_log_learning` already re-derive it from a caller-supplied path via `derive_project_name()` — with inline comments citing #48/#49 as the bugs that forced it. Hook-bound sessions populate `project_name` through that same call.

**Normalizing `project_path` at both ends was considered and rejected:**

- It fixes only new rows. There is no backfill migration (`persistence/migration.py` has no `project_path` handling), so existing rows stay stranded.
- It leaves the surface half-patched — roughly ten other raw-equality sites exist (`sqlite.py:478,499,1754,1764,1862,1865,1876`; `postgresql.py:541,568,1610,1703,1715,1804,1807,1821`, plus an in-memory one at `session_engine.py:2934`).
- `derive_project_name()` resolves symlinks, which is a stronger transform than the bug needs and could merge two intentionally-distinct checkouts.

The tool's parameter surface is **not** broken: `project_path` still works and is resolved internally; `project_name` is now also accepted directly.

## One deliberate asymmetry with the write-path precedent

If a supplied `project_path` cannot be bound to a usable name (relative path, `_unknown_` sentinel, or a derivation that comes back `_unbound_`), this returns an **empty list with a logged warning** rather than falling through to an unfiltered query.

The write paths proceed when a path can't be bound; a read path must not. Widening a call the caller explicitly scoped to one project would return *every* project's notebooks — wrong-but-plausible, the same failure class as the bug being fixed, and indistinguishable from a correct result. When no filter is requested at all, the unfiltered path is unchanged, so existing no-arg callers are unaffected.

## Depends on #61's gate

`project_name` had to be declared in the tool's registry schema as well as the engine signature — the validation gate added in #65 refuses any undeclared parameter. Worth knowing generally: **after #61, adding a parameter requires both changes**, where a signature-only change previously appeared to work over HTTP.

## Tests

| Test | Guards |
|---|---|
| `test_notebooks_found_when_queried_path_spelling_differs` | the #62 defect — **fails pre-fix** (`got []`) |
| `test_notebooks_found_when_queried_by_project_name` | the new parameter — **fails pre-fix** (`TypeError: unexpected keyword argument 'project_name'`) |
| `test_unusable_project_path_returns_empty_not_every_project` | pins the no-silent-widening choice above |
| `test_no_project_filter_still_returns_all_notebooks` | back-compat for unfiltered callers |

The first two were verified against the pre-fix tree and fail there. The last two pass in both trees — they pin decisions made *while* fixing rather than guarding the original bug, and were deliberately not contrived into failing. Stating the split explicitly so the table isn't read as four regression guards.

## Suite

`486 passed, 74 skipped, 0 failed` (560 collected).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)