### PR TITLE
fix(logging): make debug file logging opt-in and size-capped (closes #68)

### DIFF
--- a/src/core/debug_logging.py
+++ b/src/core/debug_logging.py
@@ -1,0 +1,70 @@
+"""Opt-in debug logging for session-intelligence.
+
+Debug logging is OFF unless SESSION_INTELLIGENCE_DEBUG is set to a truthy
+value. When enabled it writes to a size-capped rotating file so it cannot
+grow without bound (issue #68: the ungated handler reached 103 MB / 720k
+lines over 45 days).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+DEBUG_ENV_VAR = "SESSION_INTELLIGENCE_DEBUG"
+LOG_PATH_ENV_VAR = "SESSION_INTELLIGENCE_DEBUG_LOG"
+DEFAULT_LOG_PATH = Path("/tmp/session-intelligence-debug.log")
+MAX_BYTES = 5 * 1024 * 1024
+BACKUP_COUNT = 2
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def debug_enabled() -> bool:
+    """Return True only when debug logging is explicitly switched on."""
+    return os.environ.get(DEBUG_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def debug_log_path() -> Path:
+    """Destination for the debug log; overridable for tests and packaging."""
+    return Path(os.environ.get(LOG_PATH_ENV_VAR) or DEFAULT_LOG_PATH)
+
+
+def configure_debug_logger(name: str, fmt: str) -> logging.Logger:
+    """Return a debug logger whose file sink is opt-in.
+
+    Idempotent: existing handlers are cleared first, so repeated calls (or
+    module reloads) cannot stack duplicate sinks on the same file.
+
+    When debug is off the logger keeps propagating at WARNING, so genuine
+    failures still reach the root handlers (journal). Only the high-volume
+    INFO tracing is dropped -- that tracing is what made the log unbounded,
+    not the error records.
+    """
+    logger = logging.getLogger(name)
+
+    # Propagation stays ON in both states: these loggers carry real
+    # exception records, and the root handlers are their only sink when
+    # the debug file is disabled.
+    logger.propagate = True
+
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+
+    if not debug_enabled():
+        # No file sink; WARNING drops the INFO tracing that caused issue #68
+        # while leaving warnings/errors visible via the root handlers.
+        logger.addHandler(logging.NullHandler())
+        logger.setLevel(logging.WARNING)
+        return logger
+
+    path = debug_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(path, maxBytes=MAX_BYTES, backupCount=BACKUP_COUNT)
+    handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -7,7 +7,6 @@ capabilities.
 """
 
 import json
-import logging
 import secrets
 import uuid
 from dataclasses import dataclass
@@ -16,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from core.agent_validator import AgentValidator
+from core.debug_logging import configure_debug_logger
 from core.project_naming import UNBOUND, derive_project_name
 from models.session_models import (
     Agent,
@@ -69,15 +69,10 @@ from models.session_models import (
     WorkflowType,
 )
 
-# Setup file logging for debugging
-debug_log_file = Path("/tmp/session-intelligence-debug.log")
-debug_logger = logging.getLogger("session_intelligence_engine_debug")
-debug_handler = logging.FileHandler(debug_log_file)
-debug_handler.setFormatter(
-    logging.Formatter("%(asctime)s [ENGINE-DEBUG] %(message)s")
+# Debug logging is opt-in via SESSION_INTELLIGENCE_DEBUG (issue #68).
+debug_logger = configure_debug_logger(
+    "session_intelligence_engine_debug", "%(asctime)s [ENGINE-DEBUG] %(message)s"
 )
-debug_logger.addHandler(debug_handler)
-debug_logger.setLevel(logging.INFO)
 
 # Sentinel for "the caller did not tell us where they were working".
 # Never fall back to the server's own cwd: this process runs from the

--- a/src/session/server.py
+++ b/src/session/server.py
@@ -16,15 +16,8 @@ from fastmcp import FastMCP
 
 logger = logging.getLogger(__name__)
 
-# Setup file logging for debugging
-debug_log_file = Path("/tmp/session-intelligence-debug.log")
-debug_logger = logging.getLogger("session_intelligence_debug")
-debug_handler = logging.FileHandler(debug_log_file)
-debug_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
-debug_logger.addHandler(debug_handler)
-debug_logger.setLevel(logging.INFO)
-
 # ruff: noqa: E402
+from core.debug_logging import configure_debug_logger
 from core.session_engine import SessionIntelligenceEngine
 from models.session_models import (
     AnalysisScope,
@@ -44,6 +37,11 @@ from models.session_models import (
     WorkflowType,
 )
 from utils.token_limiter import apply_token_limits
+
+# Debug logging is opt-in via SESSION_INTELLIGENCE_DEBUG (issue #68).
+debug_logger = configure_debug_logger(
+    "session_intelligence_debug", "%(asctime)s [%(levelname)s] %(message)s"
+)
 
 
 # Parse command line arguments

--- a/tests/unit/test_debug_logging.py
+++ b/tests/unit/test_debug_logging.py
@@ -1,0 +1,172 @@
+"""Tests for opt-in, size-capped debug logging (issue #68)."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+import pytest
+
+from core.debug_logging import (
+    BACKUP_COUNT,
+    DEBUG_ENV_VAR,
+    LOG_PATH_ENV_VAR,
+    MAX_BYTES,
+    configure_debug_logger,
+)
+
+
+def _cleanup_logger(name: str) -> None:
+    logger = logging.getLogger(name)
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+
+
+@pytest.fixture
+def logger_name(request):
+    """Unique logger name per test to avoid leaking handler state."""
+    name = f"test_debug_logger.{request.node.name}"
+    yield name
+    _cleanup_logger(name)
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_disabled_by_default_never_creates_file(monkeypatch, tmp_path, logger_name):
+    monkeypatch.delenv(DEBUG_ENV_VAR, raising=False)
+    log_path = tmp_path / "debug.log"
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(log_path))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+    logger.info("this should not be written anywhere")
+
+    assert not log_path.exists()
+    assert logger.getEffectiveLevel() == logging.WARNING
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_disabled_errors_still_propagate_to_root(monkeypatch, tmp_path, logger_name, caplog):
+    monkeypatch.delenv(DEBUG_ENV_VAR, raising=False)
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(tmp_path / "debug.log"))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+
+    with caplog.at_level(logging.WARNING):
+        logger.error("genuine failure: something broke")
+
+    assert any("genuine failure: something broke" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_enabled_writes_to_file(monkeypatch, tmp_path, logger_name):
+    monkeypatch.setenv(DEBUG_ENV_VAR, "1")
+    log_path = tmp_path / "debug.log"
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(log_path))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+    logger.info("hello debug world")
+    for handler in logger.handlers:
+        handler.flush()
+
+    assert log_path.exists()
+    assert "hello debug world" in log_path.read_text()
+    assert logger.getEffectiveLevel() == logging.INFO
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("YES", True),
+        ("yes", True),
+        ("on", True),
+        ("ON", True),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("nope", False),
+    ],
+)
+def test_truthiness_of_env_var(monkeypatch, tmp_path, logger_name, value, expected):
+    monkeypatch.setenv(DEBUG_ENV_VAR, value)
+    log_path = tmp_path / "debug.log"
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(log_path))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+    logger.info("probe")
+    for handler in logger.handlers:
+        handler.flush()
+
+    assert log_path.exists() is expected
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_propagate_is_true_when_disabled(monkeypatch, tmp_path, logger_name):
+    monkeypatch.delenv(DEBUG_ENV_VAR, raising=False)
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(tmp_path / "debug.log"))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+
+    assert logger.propagate is True
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_propagate_is_true_when_enabled(monkeypatch, tmp_path, logger_name):
+    monkeypatch.setenv(DEBUG_ENV_VAR, "1")
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(tmp_path / "debug.log"))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+
+    assert logger.propagate is True
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_enabled_handler_is_rotating_with_expected_limits(monkeypatch, tmp_path, logger_name):
+    monkeypatch.setenv(DEBUG_ENV_VAR, "1")
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(tmp_path / "debug.log"))
+
+    logger = configure_debug_logger(logger_name, "%(message)s")
+
+    rotating_handlers = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating_handlers) == 1
+    handler = rotating_handlers[0]
+    assert handler.maxBytes == MAX_BYTES
+    assert handler.backupCount == BACKUP_COUNT
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_idempotent_configuration_leaves_single_handler(monkeypatch, tmp_path, logger_name):
+    monkeypatch.setenv(DEBUG_ENV_VAR, "1")
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(tmp_path / "debug.log"))
+
+    configure_debug_logger(logger_name, "%(message)s")
+    logger = configure_debug_logger(logger_name, "%(message)s")
+
+    non_null_handlers = [h for h in logger.handlers if not isinstance(h, logging.NullHandler)]
+    assert len(non_null_handlers) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.regression
+def test_idempotent_configuration_when_disabled_leaves_single_null_handler(
+    monkeypatch, tmp_path, logger_name
+):
+    monkeypatch.delenv(DEBUG_ENV_VAR, raising=False)
+    monkeypatch.setenv(LOG_PATH_ENV_VAR, str(tmp_path / "debug.log"))
+
+    configure_debug_logger(logger_name, "%(message)s")
+    logger = configure_debug_logger(logger_name, "%(message)s")
+
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0], logging.NullHandler)


### PR DESCRIPTION
Closes #68.

## Problem

The debug `FileHandler` was installed at **module import**, at `INFO` level, with no gate and no rotation. Despite the name, nothing turned it off.

- **103 MB / 720,700 lines** accumulated since Jul 1 (~2.3 MB/day), never rotated
- Captured **every project on the machine**, not just this repo — all sessions share the one server on `:4002`
- Wrote session working directories and project paths in cleartext to world-readable `/tmp`
- Two differently-named loggers (`session_intelligence_engine_debug` in `core/session_engine.py`, `session_intelligence_debug` in `session/server.py`) were both writing to the **same file**

## Change

New `src/core/debug_logging.py` exposing `configure_debug_logger()`:

- file sink installed **only** when `SESSION_INTELLIGENCE_DEBUG` is truthy (`1`/`true`/`yes`/`on`); path overridable via `SESSION_INTELLIGENCE_DEBUG_LOG`
- `RotatingFileHandler`, 5 MB × 2 backups, so it cannot grow unbounded again
- clears existing handlers first — idempotent, and repairs the two-writers-one-file setup

Call sites are untouched; the `debug_logger` name is preserved across all 139 of them.

## The non-obvious part: gate on level, not `propagate`

My first pass used `propagate=False` + a suppressing level. An audit of the call sites showed that was wrong:

| kind | count | content |
|---|---|---|
| `.info` | ~127 | high-volume tracing — the actual source of the bloat |
| `.warning` / `.error` | 54 | genuine failures: exception text, full tracebacks, `"called without database"` degradation notices |

Silencing the logger, or cutting propagation, would have taken all 54 down with the noise — and since these loggers had `propagate=True`, the journal is their **only** sink once the file is gone.

So when disabled the logger stays at `WARNING` **and keeps propagating**: the tracing disappears, the failure records still reach the root handlers. `INFO` + the rotating file only when explicitly enabled.

## Tests

19 new tests in `tests/unit/test_debug_logging.py` (`unit` + `regression` markers): disabled/enabled paths, 11-case truthiness matrix, rotation limits, idempotence in both states, and a `caplog`-based regression test asserting errors still propagate when debug is off — that one fails if `propagate` is ever flipped back.

**Suite: 512 passed, 74 skipped, 1 xfailed, 0 failed.**

`ruff check` clean on `src/` and all changed files. (Note: `ruff check tests/` reports 67 **pre-existing** errors in unrelated test files — untouched here.)

## Deployment note

The systemd service runs directly out of this working tree, so merging to `development` is effectively deploying. The existing 103 MB `/tmp/session-intelligence-debug.log` should be truncated **after** the service restarts on the merged code — truncating earlier just lets the still-running old process refill it.

## Related

Found during the investigation that also produced #67 (the root cause of the PostgreSQL CPU load), #69, and #70. This PR is the self-contained, reversible one; #67 is the substantive fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)