### PR TITLE
fix(persistence): skip unchanged rows in the session persist loop (closes #67)

### DIFF
--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -54,6 +54,7 @@ from core.session_engine import SessionIntelligenceEngine
 from lean_mcp_interface import LeanMCPInterface
 from persistence import DatabaseConfig, create_database, sanitize_dsn
 from transport.mcp_session_manager import MCPSessionManager
+from transport.persist_tracker import PersistDigestTracker
 from transport.security import (
     LocalhostOnlyMiddleware,
     SecurityConfig,
@@ -165,6 +166,11 @@ class HTTPSessionIntelligenceServer:
         self.lean_interface: LeanMCPInterface | None = None
         self.mcp_session_manager: MCPSessionManager | None = None
         self.notification_manager: NotificationManager | None = None
+
+        # Change detection for _persist_sessions_to_database (issue #67): skips
+        # re-upserting cache entries whose payload has not changed since the
+        # last successful write.
+        self.persist_tracker = PersistDigestTracker()
 
     @asynccontextmanager
     async def lifespan(self, app: FastAPI) -> AsyncGenerator[None, None]:
@@ -552,31 +558,61 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
         return {"contents": []}
 
     async def _persist_sessions_to_database(self, request: Request) -> None:
-        """Persist all sessions from engine cache to database.
+        """Persist changed sessions from engine cache to database.
 
         Saves session-level data AND related records (decisions, agent_executions).
+
+        Only entities whose payload differs from the last successful write are
+        sent to the database (issue #67). Without this, every session-modifying
+        tool call re-upserted the entire cache, producing millions of no-op
+        UPDATEs on ``agent_executions`` and keeping autovacuum continuously busy.
         """
         database = request.app.state.database
         session_engine = request.app.state.session_engine
+        tracker = self.persist_tracker
+
+        written = 0
+        skipped = 0
 
         for session_id, session in list(session_engine.session_cache.items()):
             try:
                 session_data = session.model_dump()
-                await database.save_session(session_data)
+
+                # Children are persisted separately below and are not columns of
+                # the sessions row, so they must not influence the session digest.
+                session_row = {
+                    key: value
+                    for key, value in session_data.items()
+                    if key not in ("decisions", "agents_executed")
+                }
+                digest = tracker.digest_if_changed(session_id, "session", session_row)
+                if digest is None:
+                    skipped += 1
+                else:
+                    await database.save_session(session_data)
+                    tracker.commit(session_id, "session", digest)
+                    written += 1
 
                 # Also persist decisions
-                for decision in session.decisions:
+                for index, decision in enumerate(session.decisions):
                     try:
                         decision_data = (
                             decision.model_dump() if hasattr(decision, "model_dump") else decision
                         )
                         decision_data["session_id"] = session_id
+                        entity_key = f"decision:{decision_data.get('id') or index}"
+                        digest = tracker.digest_if_changed(session_id, entity_key, decision_data)
+                        if digest is None:
+                            skipped += 1
+                            continue
                         await database.save_decision(decision_data)
+                        tracker.commit(session_id, entity_key, digest)
+                        written += 1
                     except Exception as e:
                         logger.warning(f"Failed to persist decision: {e}")
 
                 # Also persist agent executions
-                for agent_exec in session.agents_executed:
+                for index, agent_exec in enumerate(session.agents_executed):
                     try:
                         exec_data = (
                             agent_exec.model_dump()
@@ -584,7 +620,15 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
                             else agent_exec
                         )
                         exec_data["session_id"] = session_id
+                        exec_id = exec_data.get("id") or exec_data.get("execution_id") or index
+                        entity_key = f"execution:{exec_id}"
+                        digest = tracker.digest_if_changed(session_id, entity_key, exec_data)
+                        if digest is None:
+                            skipped += 1
+                            continue
                         await database.save_agent_execution(exec_data)
+                        tracker.commit(session_id, entity_key, digest)
+                        written += 1
                     except Exception as e:
                         logger.warning(f"Failed to persist agent execution: {e}")
 
@@ -593,6 +637,12 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
                 )
             except Exception as e:
                 logger.error(f"Failed to persist session {session_id}: {e}")
+
+        # Digests only shadow the cache; drop entries for sessions that have left
+        # it so the tracker cannot grow without bound.
+        tracker.retain(session_engine.session_cache.keys())
+
+        logger.debug(f"Persist pass: {written} written, {skipped} unchanged")
 
     async def _ensure_sessions_loaded_from_database(self, request: Request) -> None:
         """Load active sessions from database into engine cache if cache is empty.

--- a/src/transport/persist_tracker.py
+++ b/src/transport/persist_tracker.py
@@ -1,0 +1,80 @@
+"""Content-digest change detection for session persistence (issue #67).
+
+``_persist_sessions_to_database`` used to walk the entire session cache and
+unconditionally re-upsert every session, decision and agent execution it held,
+on *every* session-modifying tool call. That produced ~1,435 UPDATEs per row on
+``agent_executions`` and kept autovacuum near-continuously busy.
+
+This module records a content digest per persisted entity so a payload that is
+byte-identical to what was last written successfully can be skipped. Digests are
+committed only *after* a successful write, so a failed or retried write is
+attempted again on the next pass rather than being silently dropped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+__all__ = ["PersistDigestTracker", "compute_digest"]
+
+
+def compute_digest(payload: Mapping[str, Any]) -> str:
+    """Return a stable digest of ``payload``.
+
+    Falls back to a unique value when the payload cannot be canonicalised, which
+    makes the entity look changed and preserves the pre-#67 always-write
+    behaviour rather than skipping a write we cannot prove is redundant.
+    """
+    try:
+        canonical = json.dumps(payload, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return f"uncomparable:{uuid.uuid4().hex}"
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class PersistDigestTracker:
+    """Track the last successfully persisted digest per entity, grouped by session.
+
+    Entities are addressed by ``(session_id, entity_key)``. Grouping by session
+    lets :meth:`retain` drop every digest belonging to a session that has left
+    the cache, so the tracker cannot outgrow the cache it shadows.
+    """
+
+    def __init__(self) -> None:
+        self._digests: dict[str, dict[str, str]] = {}
+
+    def digest_if_changed(
+        self, session_id: str, entity_key: str, payload: Mapping[str, Any]
+    ) -> str | None:
+        """Return the digest to commit if ``payload`` differs from the last write.
+
+        Returns ``None`` when the payload is unchanged and the write can be
+        skipped.
+        """
+        digest = compute_digest(payload)
+        if self._digests.get(session_id, {}).get(entity_key) == digest:
+            return None
+        return digest
+
+    def commit(self, session_id: str, entity_key: str, digest: str) -> None:
+        """Record ``digest`` as successfully persisted. Call only after the write."""
+        self._digests.setdefault(session_id, {})[entity_key] = digest
+
+    def retain(self, session_ids: Iterable[str]) -> None:
+        """Drop digests for every session not in ``session_ids``."""
+        keep = set(session_ids)
+        for session_id in list(self._digests):
+            if session_id not in keep:
+                del self._digests[session_id]
+
+    def forget(self, session_id: str) -> None:
+        """Drop all digests for a single session, forcing a rewrite next pass."""
+        self._digests.pop(session_id, None)
+
+    def tracked_entity_count(self) -> int:
+        """Total number of tracked entities. Intended for tests and diagnostics."""
+        return sum(len(entities) for entities in self._digests.values())

--- a/tests/regression/test_issue_67_persist_change_detection.py
+++ b/tests/regression/test_issue_67_persist_change_detection.py
@@ -1,0 +1,296 @@
+"""Regression tests for issue #67: persist loop re-upserted the entire cache.
+
+Bug: ``_persist_sessions_to_database`` walked the whole ``session_cache`` and
+     unconditionally re-upserted every session, every decision and every agent
+     execution after *each* session-modifying tool call. Measured at ~12.8 no-op
+     UPDATE/sec on ``agent_executions`` while the server was idle, with 1,626
+     autovacuum runs on that one table.
+Fix: a content digest is recorded per entity; a payload identical to the last
+     successful write is skipped, and digests are committed only *after* the
+     write succeeds so failures are retried.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.session_engine import SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+from transport.http_server import HTTPSessionIntelligenceServer
+from transport.persist_tracker import PersistDigestTracker, compute_digest
+
+
+class CountingDatabase:
+    """Records every save call so tests can assert on write volume."""
+
+    def __init__(self) -> None:
+        self.sessions: list[str] = []
+        self.decisions: list[str] = []
+        self.agent_executions: list[str] = []
+
+    def reset(self) -> None:
+        self.sessions.clear()
+        self.decisions.clear()
+        self.agent_executions.clear()
+
+    async def save_session(self, session_data):
+        self.sessions.append(session_data["id"])
+
+    async def save_decision(self, decision_data):
+        self.decisions.append(decision_data.get("id"))
+
+    async def save_agent_execution(self, execution_data):
+        self.agent_executions.append(execution_data.get("id") or execution_data.get("execution_id"))
+
+
+class FailingDecisionDatabase(CountingDatabase):
+    """Fails every ``save_decision`` to prove digests are not committed on failure."""
+
+    async def save_decision(self, decision_data):
+        self.decisions.append(decision_data.get("id"))
+        raise RuntimeError("simulated decision write failure")
+
+
+class StubEntity:
+    """Minimal stand-in for a Decision / AgentExecution pydantic model."""
+
+    def __init__(self, entity_id: str, **fields) -> None:
+        self._data = {"id": entity_id, **fields}
+
+    def model_dump(self):
+        return dict(self._data)
+
+    def mutate(self, key: str, value) -> None:
+        self._data[key] = value
+
+
+class StubSession:
+    """Minimal stand-in for a Session pydantic model."""
+
+    def __init__(self, session_id: str, decisions=None, agents_executed=None) -> None:
+        self.id = session_id
+        self.status = "active"
+        self.decisions = decisions if decisions is not None else []
+        self.agents_executed = agents_executed if agents_executed is not None else []
+
+    def model_dump(self):
+        return {
+            "id": self.id,
+            "status": self.status,
+            "decisions": [d.model_dump() for d in self.decisions],
+            "agents_executed": [a.model_dump() for a in self.agents_executed],
+        }
+
+
+def make_server() -> HTTPSessionIntelligenceServer:
+    """Build a server without running ``__init__`` (which would load DB config)."""
+    server = HTTPSessionIntelligenceServer.__new__(HTTPSessionIntelligenceServer)
+    server.persist_tracker = PersistDigestTracker()
+    return server
+
+
+def make_request(database, session_cache):
+    engine = SimpleNamespace(session_cache=session_cache)
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(database=database, session_engine=engine))
+    )
+
+
+@pytest.mark.regression
+class TestPersistDigestTracker:
+    def test_unchanged_payload_is_skipped_after_commit(self):
+        tracker = PersistDigestTracker()
+        payload = {"id": "d1", "text": "hello"}
+
+        digest = tracker.digest_if_changed("s1", "decision:d1", payload)
+        assert digest is not None
+        tracker.commit("s1", "decision:d1", digest)
+
+        assert tracker.digest_if_changed("s1", "decision:d1", payload) is None
+
+    def test_changed_payload_is_not_skipped(self):
+        tracker = PersistDigestTracker()
+        digest = tracker.digest_if_changed("s1", "decision:d1", {"id": "d1", "n": 1})
+        tracker.commit("s1", "decision:d1", digest)
+
+        assert tracker.digest_if_changed("s1", "decision:d1", {"id": "d1", "n": 2}) is not None
+
+    def test_uncommitted_digest_leaves_entity_dirty(self):
+        """A digest that is never committed (failed write) must stay dirty."""
+        tracker = PersistDigestTracker()
+        payload = {"id": "d1"}
+
+        assert tracker.digest_if_changed("s1", "decision:d1", payload) is not None
+        assert tracker.digest_if_changed("s1", "decision:d1", payload) is not None
+
+    def test_retain_drops_digests_for_evicted_sessions(self):
+        tracker = PersistDigestTracker()
+        for session_id in ("s1", "s2"):
+            digest = tracker.digest_if_changed(session_id, "session", {"id": session_id})
+            tracker.commit(session_id, "session", digest)
+        assert tracker.tracked_entity_count() == 2
+
+        tracker.retain(["s1"])
+
+        assert tracker.tracked_entity_count() == 1
+        assert tracker.digest_if_changed("s1", "session", {"id": "s1"}) is None
+        assert tracker.digest_if_changed("s2", "session", {"id": "s2"}) is not None
+
+    def test_forget_drops_a_single_session(self):
+        tracker = PersistDigestTracker()
+        digest = tracker.digest_if_changed("s1", "session", {"id": "s1"})
+        tracker.commit("s1", "session", digest)
+
+        tracker.forget("s1")
+
+        assert tracker.digest_if_changed("s1", "session", {"id": "s1"}) is not None
+
+    def test_digest_ignores_key_insertion_order(self):
+        assert compute_digest({"a": 1, "b": 2}) == compute_digest({"b": 2, "a": 1})
+
+    def test_uncanonicalisable_payload_always_looks_changed(self):
+        """Mixed key types break sort_keys; fall back to always-write, never skip."""
+        payload = {"a": 1, 2: "b"}
+        assert compute_digest(payload) != compute_digest(payload)
+
+
+@pytest.mark.regression
+class TestPersistSessionsToDatabase:
+    async def test_first_pass_writes_every_entity(self):
+        session = StubSession(
+            "s1",
+            decisions=[StubEntity("d1"), StubEntity("d2")],
+            agents_executed=[StubEntity("e1"), StubEntity("e2"), StubEntity("e3")],
+        )
+        database = CountingDatabase()
+        server = make_server()
+
+        await server._persist_sessions_to_database(make_request(database, {"s1": session}))
+
+        assert database.sessions == ["s1"]
+        assert database.decisions == ["d1", "d2"]
+        assert database.agent_executions == ["e1", "e2", "e3"]
+
+    async def test_second_pass_without_changes_writes_nothing(self):
+        """The #67 bug: this pass used to re-upsert all six rows again."""
+        session = StubSession(
+            "s1",
+            decisions=[StubEntity("d1"), StubEntity("d2")],
+            agents_executed=[StubEntity("e1"), StubEntity("e2"), StubEntity("e3")],
+        )
+        database = CountingDatabase()
+        server = make_server()
+        request = make_request(database, {"s1": session})
+
+        await server._persist_sessions_to_database(request)
+        database.reset()
+        await server._persist_sessions_to_database(request)
+
+        assert database.sessions == []
+        assert database.decisions == []
+        assert database.agent_executions == []
+
+    async def test_only_the_changed_execution_is_rewritten(self):
+        executions = [StubEntity("e1"), StubEntity("e2"), StubEntity("e3")]
+        session = StubSession("s1", agents_executed=executions)
+        database = CountingDatabase()
+        server = make_server()
+        request = make_request(database, {"s1": session})
+
+        await server._persist_sessions_to_database(request)
+        database.reset()
+        executions[1].mutate("status", "completed")
+        await server._persist_sessions_to_database(request)
+
+        assert database.agent_executions == ["e2"]
+
+    async def test_appended_decision_does_not_rewrite_existing_ones(self):
+        decisions = [StubEntity("d1"), StubEntity("d2")]
+        session = StubSession("s1", decisions=decisions)
+        database = CountingDatabase()
+        server = make_server()
+        request = make_request(database, {"s1": session})
+
+        await server._persist_sessions_to_database(request)
+        database.reset()
+        decisions.append(StubEntity("d3"))
+        await server._persist_sessions_to_database(request)
+
+        assert database.decisions == ["d3"]
+
+    async def test_failed_write_is_retried_on_the_next_pass(self):
+        session = StubSession("s1", decisions=[StubEntity("d1")])
+        database = FailingDecisionDatabase()
+        server = make_server()
+        request = make_request(database, {"s1": session})
+
+        await server._persist_sessions_to_database(request)
+        database.reset()
+        await server._persist_sessions_to_database(request)
+
+        assert database.decisions == [
+            "d1"
+        ], "A decision whose write failed must not have its digest committed"
+
+    async def test_evicted_session_is_rewritten_when_it_returns(self):
+        session = StubSession("s1", decisions=[StubEntity("d1")])
+        database = CountingDatabase()
+        server = make_server()
+
+        await server._persist_sessions_to_database(make_request(database, {"s1": session}))
+        await server._persist_sessions_to_database(make_request(database, {}))
+        assert server.persist_tracker.tracked_entity_count() == 0
+
+        database.reset()
+        await server._persist_sessions_to_database(make_request(database, {"s1": session}))
+
+        assert database.sessions == ["s1"]
+        assert database.decisions == ["d1"]
+
+    async def test_tracker_does_not_outgrow_the_cache(self):
+        database = CountingDatabase()
+        server = make_server()
+
+        for index in range(5):
+            session_id = f"s{index}"
+            session = StubSession(session_id, decisions=[StubEntity(f"d{index}")])
+            await server._persist_sessions_to_database(
+                make_request(database, {session_id: session})
+            )
+
+        assert server.persist_tracker.tracked_entity_count() == 2
+
+
+@pytest.mark.regression
+class TestPersistWithRealSessionModel:
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_repeat_persist_of_real_session_writes_nothing(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="issue-67"
+        )
+        await engine.session_log_decision(
+            decision="Digest the payload instead of always upserting",
+            context={"rationale": "issue #67", "category": "test"},
+        )
+        assert engine.session_cache
+
+        database = CountingDatabase()
+        server = make_server()
+        request = make_request(database, engine.session_cache)
+
+        await server._persist_sessions_to_database(request)
+        assert database.sessions, "first pass must persist the session"
+        database.reset()
+
+        await server._persist_sessions_to_database(request)
+
+        assert database.sessions == []
+        assert database.decisions == []
+        assert database.agent_executions == []


### PR DESCRIPTION
## Summary

Fixes #67. `_persist_sessions_to_database` walked the whole `session_cache` and unconditionally re-upserted **every** session, decision and agent execution after **each** session-modifying tool call. Measured on the production DB:

| table | rows | updates | autovacuum runs |
|---|---|---|---|
| `agent_executions` | 14,724 | **21,127,557** | **1,626** |
| `sessions` | 7,751 | 793,084 | 3 |
| `decisions` | 6,391 | 341,113 | 2 |

~1,435 updates per row on `agent_executions`, and **12.8 updates/sec sustained while idle** against an insert rate of only ~600/day.

## Approach

Content-digest change detection rather than dirty-flag tracking threaded through the engine's ~35 `session_cache` mutation sites. The reasoning: a missed mutation path under dirty-flagging means **silent data loss**, whereas the same miss under hashing costs only one redundant write. It is also localized to the persist path instead of touching `session_engine.py` throughout.

New `src/transport/persist_tracker.py` records a digest per persisted entity; the write is skipped when the payload is byte-identical to the last successful one.

## Invariants that keep this from becoming a data-loss bug

- **Digests commit only after a successful write.** A failed or retried `save_*` leaves the entity dirty so it is attempted again on the next pass, rather than being permanently skipped.
- **Digests are grouped by `session_id`,** so `retain()` prunes entries wholesale for sessions that have left the cache — the tracker cannot outgrow the cache it shadows. A session that leaves and returns is rewritten once.
- **An uncanonicalisable payload always looks changed.** Mixed key types break `json.dumps(sort_keys=True)`; that path returns a unique digest, degrading to the previous always-write behaviour rather than skipping a write we cannot prove is redundant.
- **The session digest excludes `decisions`/`agents_executed`,** which are not columns of the sessions row — otherwise appending one decision would re-upsert the parent.

A side effect worth noting: `save_session` fires `pg_notify('session_changes', ...)` on every call, so redundant change notifications stop too.

## Testing

`tests/regression/test_issue_67_persist_change_detection.py` — 15 tests covering the tracker in isolation, the persist loop against stubs (first pass writes everything; unchanged second pass writes nothing; only the mutated execution is rewritten; appending a decision does not rewrite existing ones; a failed write retries; eviction drops digests; the tracker does not outgrow the cache), plus one test against the real `Session` model via the engine.

```
527 passed, 74 skipped, 1 xfailed in 55.29s
```

Baseline was 512/74/1, so this is +15 new tests with zero regressions. `pixi run --environment ci lint` passes.

## Notes for the reviewer

- **This only takes effect on restart** — the service runs directly out of the git working tree.
- `closes #67` will **not** auto-close the issue: this PR targets `development`, not the repo default branch. #67 needs closing by hand after merge.
- Companion issues remain open and are not addressed here: **#69** (stale `active` sessions feed this loop — a contributing cause) and **#70** (executions stuck at `running` from the incomplete #39 fix are re-written forever).

🤖 Generated with [Claude Code](https://claude.com/claude-code)