### PR TITLE
fix(session): bind records to the caller's scope, not ambient shared state (closes #72)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -213,6 +213,7 @@ class SessionIntelligenceEngine:
         *,
         allow_unbound: bool = False,
         create_if_missing: bool = True,
+        project_path: str | None = None,
     ) -> "ResolvedSessionContext":
         """Resolve a session ID from a flexible identifier set.
 
@@ -226,10 +227,25 @@ class SessionIntelligenceEngine:
         or via _get_or_create_current_session_id (kept for back-compat in code
         paths that don't go through the resolver).
 
+        Args:
+            project_path: Absolute path recorded on any session this call
+                creates; ignored when relative.
+
         Returns:
             ResolvedSessionContext with session_id, project_name, project_path
             populated from the resolved session row.
         """
+        # Only an absolute path is trustworthy: derive_project_name() and the
+        # session row alike resolve a relative path against the SERVER's cwd,
+        # not the caller's (see the #48/#49 rationale in session_log_decision).
+        safe_project_path = (
+            project_path
+            if project_path
+            and project_path != UNKNOWN_PROJECT_PATH
+            and Path(project_path).is_absolute()
+            else None
+        )
+
         # 1. session_id: trust caller, validate
         if session_id is not None:
             if not self.database:
@@ -277,7 +293,7 @@ class SessionIntelligenceEngine:
             result = self._create_session(
                 mode="explicit",
                 project_name=project_name or "_unbound_",
-                metadata={"session_name": session_name},
+                metadata={"session_name": session_name, "project_path": safe_project_path},
                 session_name=session_name,
             )
             cached = self.session_cache.get(result.session_id)
@@ -307,7 +323,7 @@ class SessionIntelligenceEngine:
             result = self._create_session(
                 mode="explicit",
                 project_name=project_name,
-                metadata={},
+                metadata={"project_path": safe_project_path},
             )
             cached = self.session_cache.get(result.session_id)
             return ResolvedSessionContext(
@@ -479,6 +495,7 @@ class SessionIntelligenceEngine:
         operation: str,
         mode: str = "local",
         project_name: str | None = None,
+        project_path: str | None = None,
         metadata: dict[str, Any] | None = None,
         auto_recovery: bool = True,
     ) -> SessionResult:
@@ -494,7 +511,7 @@ class SessionIntelligenceEngine:
         """
         try:
             return await self._manage_lifecycle_impl(
-                operation, mode, project_name, metadata, auto_recovery
+                operation, mode, project_name, project_path, metadata, auto_recovery
             )
         except Exception as e:
             return SessionResult(
@@ -509,14 +526,21 @@ class SessionIntelligenceEngine:
         operation: str,
         mode: str,
         project_name: str | None,
+        project_path: str | None,
         metadata: dict[str, Any] | None,
         auto_recovery: bool,
     ) -> SessionResult:
         """Session lifecycle management."""
 
         if operation == "create":
+            create_metadata = dict(metadata or {})
+            if not create_metadata.get("project_path") and project_path:
+                # Relative paths would resolve against the server's cwd, not the
+                # caller's, so only an absolute path is recorded (issue #72).
+                if Path(project_path).is_absolute():
+                    create_metadata["project_path"] = project_path
             result = self._create_session(
-                mode, project_name, metadata or {}, session_name=None
+                mode, project_name, create_metadata, session_name=None
             )
             # Persist session to DB so FK references work
             if result.status == "success" and self.database:
@@ -1290,10 +1314,10 @@ class SessionIntelligenceEngine:
             # discarded rather than used, to avoid recreating the invisible-rows
             # bug #48 fixed.
             #
-            # This runs BEFORE the in-process-session guard below so that an
-            # explicit project_path wins over the ambient current session. That
-            # reorders nothing in practice: project_path was previously a
-            # TypeError on this method, so no existing caller can reach here.
+            # This runs BEFORE the scope check below, so a caller who supplies
+            # only project_path still resolves instead of being rejected. The
+            # in-process-session guard this used to precede was removed in
+            # issue #72; see the comment on that check.
             if (
                 not (session_id or session_name or project_name)
                 and not allow_unbound
@@ -1305,23 +1329,23 @@ class SessionIntelligenceEngine:
                 if derived_name != UNBOUND:
                     project_name = derived_name
 
-            # If no identifier given but a current session was created by THIS
-            # process, thread it as session_id so the resolver validates rather
-            # than falling through to the unbound path.  The guard is gated on
-            # _current_session_set_in_process so that a stale session ID loaded
-            # from disk at startup does NOT silently hijack the call — that
-            # would defeat the SessionContextRequiredError guarantee.
+            # An in-process current session used to be substituted here when the
+            # caller supplied no identifier. That guard assumed one engine per
+            # project; the HTTP transport builds a SINGLE engine shared by every
+            # project (http_server.py lifespan()), so
+            # _current_session_set_in_process turns True as soon as ANY project
+            # creates a session in this process. An unbound decision then bound
+            # silently to whichever project most recently created one — issue
+            # #72, where session-intelligence decisions landed under
+            # package-incubator. Demand a scope instead, exactly as
+            # session_log_learning already does.
+            if not (session_id or session_name or project_name) and not allow_unbound:
+                raise SessionContextRequiredError(
+                    "session_log_decision requires at least one of: "
+                    "session_id, session_name, project_name. "
+                    "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+                )
             effective_session_id = session_id
-            if (
-                effective_session_id is None
-                and session_name is None
-                and project_name is None
-                and not allow_unbound
-                and self._current_session_id
-                and self._current_session_id in self.session_cache
-                and self._current_session_set_in_process
-            ):
-                effective_session_id = self._current_session_id
 
             # Resolve session via the flexible resolver
             resolved = await self._resolve_session_context(
@@ -1329,6 +1353,7 @@ class SessionIntelligenceEngine:
                 session_name=session_name,
                 project_name=project_name,
                 allow_unbound=allow_unbound,
+                project_path=project_path,
             )
             resolved_id = resolved.session_id
             # Persist newly-created session to DB if needed
@@ -2812,6 +2837,7 @@ class SessionIntelligenceEngine:
                 session_name=session_name,
                 project_name=project_name,
                 allow_unbound=allow_unbound,
+                project_path=project_path,
             )
             resolved_session_id = resolved_ctx.session_id
             # Persist newly-created session to DB if needed

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -81,6 +81,14 @@ class LeanMCPInterface:
                         "description": "Session mode",
                     },
                     "project_name": {"type": "string", "description": "Project context (optional)"},
+                    "project_path": {
+                        "type": "string",
+                        "description": (
+                            "Absolute path to the caller's project, recorded on the "
+                            "created session. Relative paths are ignored (they would "
+                            "resolve against the server's cwd, not the caller's)."
+                        ),
+                    },
                     "metadata": {"description": "Additional session metadata"},
                     "auto_recovery": {
                         "type": "boolean",

--- a/tests/integration/test_error_paths.py
+++ b/tests/integration/test_error_paths.py
@@ -101,7 +101,7 @@ async def test_log_decision_missing_decision_raises(lean):
 async def test_log_decision_empty_string_is_accepted(lean):
     """session_log_decision with empty string decision does not crash."""
     await _call(lean, "session_manage_lifecycle", operation="create", project_name="ep-test")
-    result = await _call(lean, "session_log_decision", decision="")
+    result = await _call(lean, "session_log_decision", decision="", project_name="ep-test")
     # Empty string is technically valid — engine returns some result
     assert result is not None
 
@@ -109,7 +109,7 @@ async def test_log_decision_empty_string_is_accepted(lean):
 async def test_log_decision_none_context_is_handled(lean):
     """session_log_decision with context=None does not crash."""
     await _call(lean, "session_manage_lifecycle", operation="create", project_name="ctx-test")
-    result = await _call(lean, "session_log_decision", decision="test decision", context=None)
+    result = await _call(lean, "session_log_decision", decision="test decision", context=None, project_name="ctx-test")
     assert result is not None
 
 

--- a/tests/regression/test_async_await_bugs.py
+++ b/tests/regression/test_async_await_bugs.py
@@ -33,6 +33,7 @@ class TestAsyncAwaitBugs:
         await engine.session_log_decision(
             decision="Test decision",
             context={"rationale": "Test rationale", "category": "test"},
+            session_id=session_id,
         )
 
         decisions = await engine.database.query_decisions_by_session(session_id)

--- a/tests/regression/test_issue_67_persist_change_detection.py
+++ b/tests/regression/test_issue_67_persist_change_detection.py
@@ -278,6 +278,7 @@ class TestPersistWithRealSessionModel:
         await engine.session_log_decision(
             decision="Digest the payload instead of always upserting",
             context={"rationale": "issue #67", "category": "test"},
+            project_name="issue-67",
         )
         assert engine.session_cache
 

--- a/tests/regression/test_issue_72_project_session_binding.py
+++ b/tests/regression/test_issue_72_project_session_binding.py
@@ -1,0 +1,224 @@
+"""
+Regression tests for issue #72: unbound decisions/learnings silently bound to
+whichever project most recently created a session in the shared engine.
+
+Bug: session_log_decision used to fall back to the in-process
+     "_current_session_id" when no session_id/session_name/project_name was
+     supplied. The HTTP transport builds a SINGLE SessionIntelligenceEngine
+     shared by every project (see http_server.py lifespan()), so that ambient
+     fallback bound to whichever project most recently created a session in
+     the process -- not the caller's project. Decisions for
+     session-intelligence itself landed under package-incubator.
+Fix: session_log_decision now raises SessionContextRequiredError when none of
+     session_id/session_name/project_name is supplied (unless
+     allow_unbound=True is explicitly passed), matching session_log_learning.
+     session_manage_lifecycle(operation="create", ...) also now records an
+     absolute caller-supplied project_path on the session instead of always
+     stamping the UNKNOWN_PROJECT_PATH sentinel.
+"""
+
+import pytest
+
+from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine, UNKNOWN_PROJECT_PATH
+from persistence.sqlite import SQLiteBackend
+
+
+@pytest.mark.regression
+class TestUnboundDecisionIsRejected:
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_unbound_decision_raises_even_after_ambient_session_exists(self, engine):
+        """The core #72 regression: an in-process current session must NOT
+        silently satisfy an unscoped session_log_decision call."""
+        create_result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+        assert create_result.status == "success", (
+            "Precondition failed: session_manage_lifecycle(create) did not "
+            "succeed, so this test cannot exercise the #72 ambient-session "
+            "bleed scenario."
+        )
+
+        with pytest.raises(SessionContextRequiredError):
+            await engine.session_log_decision(decision="Unscoped decision")
+
+    async def test_allow_unbound_escape_hatch_still_works(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        result = await engine.session_log_decision(
+            decision="Unscoped but explicitly allowed",
+            allow_unbound=True,
+        )
+        assert result is not None
+
+    async def test_decision_with_project_name_does_not_raise(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        result = await engine.session_log_decision(
+            decision="Scoped decision",
+            project_name="proj-a",
+        )
+        assert result is not None
+
+
+@pytest.mark.regression
+class TestCreateRecordsProjectPath:
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_absolute_project_path_is_stored(self, engine, tmp_path):
+        abs_path = str(tmp_path / "proj-a")
+
+        result = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=abs_path,
+        )
+
+        db_session = await engine.database.get_session(result.session_id)
+        assert db_session is not None
+        assert db_session["project_path"] == abs_path, (
+            "An absolute caller-supplied project_path must be recorded "
+            "verbatim on the session, not discarded in favor of the "
+            f"{UNKNOWN_PROJECT_PATH!r} sentinel."
+        )
+        assert db_session["project_path"] != UNKNOWN_PROJECT_PATH
+
+    async def test_relative_project_path_is_ignored_and_sentinel_stored(self, engine):
+        result = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path="relative/proj-a",
+        )
+
+        db_session = await engine.database.get_session(result.session_id)
+        assert db_session is not None
+        assert db_session["project_path"] == UNKNOWN_PROJECT_PATH, (
+            "A relative project_path resolves against the SERVER's cwd, not "
+            "the caller's, so it must be rejected and the "
+            f"{UNKNOWN_PROJECT_PATH!r} sentinel stored instead -- otherwise "
+            "sessions get misattributed the same way issue #72 did."
+        )
+
+    async def test_omitted_project_path_stores_sentinel(self, engine):
+        result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        db_session = await engine.database.get_session(result.session_id)
+        assert db_session is not None
+        assert db_session["project_path"] == UNKNOWN_PROJECT_PATH
+
+
+@pytest.mark.regression
+class TestSharedEngineDoesNotBleedAcrossProjects:
+    """Every existing resolver test built a FRESH engine per test, hiding
+    #72: the HTTP transport builds ONE engine shared across all projects.
+    These tests reuse a single engine for two different projects."""
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_decision_binds_to_named_project_not_most_recently_created(
+        self, engine, tmp_path
+    ):
+        proj_a_path = str(tmp_path / "proj-a")
+        proj_b_path = str(tmp_path / "proj-b")
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=proj_a_path,
+        )
+        # proj-b is created SECOND, i.e. it is the most-recently-created
+        # session in this shared engine when the decision below is logged.
+        await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=proj_b_path,
+        )
+
+        result = await engine.session_log_decision(
+            decision="Decision scoped to proj-a",
+            project_name="proj-a",
+        )
+
+        assert result.session_id == proj_a_create.session_id, (
+            "Issue #72: the decision resolved to the wrong session. It must "
+            "bind to proj-a's session (the caller's project_name), not to "
+            "proj-b's session merely because proj-b's was created most "
+            "recently in this shared engine."
+        )
+
+        db_session = await engine.database.get_session(result.session_id)
+        assert db_session is not None
+        assert db_session["project_path"] == proj_a_path, (
+            "Issue #72: decision resolved to a session whose project_path "
+            f"is {db_session['project_path']!r}, but it should be proj-a's "
+            f"path {proj_a_path!r}, not proj-b's."
+        )
+
+    async def test_learning_binds_to_named_project_not_most_recently_created(
+        self, engine, tmp_path
+    ):
+        proj_a_path = str(tmp_path / "proj-a")
+        proj_b_path = str(tmp_path / "proj-b")
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=proj_a_path,
+        )
+        await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=proj_b_path,
+        )
+
+        result = await engine.session_log_learning(
+            category="pattern",
+            learning_content="Learning scoped to proj-a",
+            trigger_context="Testing issue #72 project binding",
+            project_name="proj-a",
+        )
+
+        assert result.learning is not None
+        assert result.learning.source_session_id == proj_a_create.session_id, (
+            "Issue #72: the learning's source_session_id resolved to the "
+            "wrong session. It must bind to proj-a's session (the caller's "
+            "project_name), not to proj-b's session merely because proj-b's "
+            "was created most recently in this shared engine."
+        )
+        assert result.learning.project_path == proj_a_path, (
+            "Issue #72: learning resolved to project_path "
+            f"{result.learning.project_path!r}, but it should be proj-a's "
+            f"path {proj_a_path!r}, not proj-b's."
+        )

--- a/tests/regression/test_session_persistence_bugs.py
+++ b/tests/regression/test_session_persistence_bugs.py
@@ -59,6 +59,7 @@ class TestSessionPersistenceBugs:
         await engine.session_log_decision(
             decision="FK test decision",
             context={"rationale": "Verify FK satisfied", "category": "test"},
+            session_id=session_id,
         )
 
         decisions = await engine.database.query_decisions_by_session(session_id)

--- a/tests/test_session_recall_project_binding.py
+++ b/tests/test_session_recall_project_binding.py
@@ -103,7 +103,20 @@ async def test_log_without_create_raises_without_allow_unbound(db):
 
 
 @pytest.mark.asyncio
-async def test_create_then_log_uses_current_session(db):
+async def test_create_then_log_requires_explicit_scope(db):
+    """Issue #72 reversed this case.
+
+    Creating a session in-process used to be enough for a later unbound
+    session_log_decision to bind to it.  That premise held only for a
+    single-project engine; the HTTP transport shares ONE engine across every
+    project (http_server.py lifespan()), so the in-process flag never proved
+    the session belonged to the caller's project.
+
+    The decision must now carry an explicit scope -- and when it does, the row
+    still lands under that session.
+    """
+    from core.session_engine import SessionContextRequiredError
+
     pn = f"test-proj-{uuid.uuid4().hex[:8]}"
     engine = _make_engine(db)
     try:
@@ -116,7 +129,14 @@ async def test_create_then_log_uses_current_session(db):
 
         await db.save_session(create_result.session_data.model_dump(mode="python"))
 
-        result = await engine.session_log_decision(decision="create-then-log-probe")
+        # The ambient current session no longer licenses an unbound call.
+        with pytest.raises(SessionContextRequiredError):
+            await engine.session_log_decision(decision="create-then-log-probe")
+
+        # Passing the id that create returned is the documented replacement.
+        result = await engine.session_log_decision(
+            decision="create-then-log-probe", session_id=sid
+        )
         assert result.decision_id != "error"
 
         pool = db._ensure_connected()

--- a/tests/unit/test_pre_resolver_guard.py
+++ b/tests/unit/test_pre_resolver_guard.py
@@ -1,10 +1,14 @@
 """
 Unit tests for the pre-resolver guard in session_log_decision.
 
-Verifies that _current_session_set_in_process correctly gates the guard so
-that a stale disk-cached session ID does NOT silently hijack calls that
-provide no explicit identifier (leak mode 1) and does NOT override an
+Verifies that a stale disk-cached session ID does NOT silently hijack calls
+that provide no explicit identifier (leak mode 1) and does NOT override an
 explicit project_name/session_id (leak mode 2).
+
+Since issue #72 the in-process flag no longer licenses an unbound call
+either: _current_session_set_in_process only proves *this process* created a
+session, and the HTTP transport shares one engine across every project, so it
+never proved the session belonged to the caller's project.
 """
 
 import pytest
@@ -57,13 +61,25 @@ class TestPreResolverGuard:
         with pytest.raises(SessionContextRequiredError):
             await engine.session_log_decision(decision="some decision")
 
-    async def test_no_identifier_after_in_process_create_continues(self, engine, db):
+    async def test_no_identifier_after_in_process_create_now_raises(self, engine, db):
         """
-        Happy path: when THIS process explicitly created a session via
-        _create_session, both _current_session_id and _current_session_set_in_process
-        are set.  A no-identifier call should bind to that session and succeed.
+        Issue #72 reversed this case.  It used to be the "happy path": an
+        in-process _create_session set both _current_session_id and
+        _current_session_set_in_process, and a no-identifier call bound to
+        that session.
+
+        The premise was "this process created it, so it is mine" — true for a
+        single-project stdio server, false for the HTTP transport, which builds
+        ONE engine shared by every project (http_server.py lifespan()).  There
+        the flag turns True as soon as ANY project creates a session, so an
+        unbound call bound to whichever project most recently created one.
+        That is how session-intelligence decisions ended up filed under
+        package-incubator.
+
+        The contract now matches session_log_learning: supply a scope, or pass
+        allow_unbound=True.  Callers that want the old create-then-log flow
+        pass the session_id that _create_session returned.
         """
-        # Create a real session so FK persists correctly
         result = engine._create_session(
             mode="local",
             project_name="test-project",
@@ -73,13 +89,20 @@ class TestPreResolverGuard:
         assert result.status == "success"
         await db.save_session(result.session_data.model_dump(mode="python"))
 
-        # Both fields must be set by _create_session
+        # The ambient state the old guard keyed on is still set ...
         assert engine._current_session_id == result.session_id
         assert engine._current_session_set_in_process is True
 
-        # No identifier passed — guard should fire and use current session
+        # ... but it is no longer sufficient to bind a decision.
+        with pytest.raises(SessionContextRequiredError):
+            await engine.session_log_decision(
+                decision="a decision without explicit identifier"
+            )
+
+        # The documented replacement: pass the id the create returned.
         decision_result = await engine.session_log_decision(
-            decision="a decision without explicit identifier"
+            decision="a decision with the created session's id",
+            session_id=result.session_id,
         )
         assert decision_result.decision_id != "error"
         assert decision_result.session_id == result.session_id


### PR DESCRIPTION
Fixes #72.

## The bug

`session_log_decision` substituted the engine's ambient `_current_session_id` when the caller supplied no identifier, gated on `_current_session_set_in_process`. The guard's own comment explained the premise: *"a session created by THIS process"* is safe to bind to.

That premise assumes **one engine per project**. `src/transport/http_server.py` builds a **single** `SessionIntelligenceEngine` in `lifespan()` and shares it across every project's requests, so the flag turns `True` as soon as *any* project creates a session. An unbound decision then bound to whichever project most recently created one.

Observed live while working this issue: three `session_log_decision` calls about session-intelligence work landed in three different sessions, two of them belonging to **package-incubator**.

| call | landed in | that session's project |
|---|---|---|
| 1 | `session-20260816-114726-971621` | session-intelligence, `project_path: _unknown_`, status `completed` |
| 2 | `7d406ebb…` | **package-incubator** |
| 3 | `592dc9ec…` | **package-incubator** |

The write succeeds and the envelope says `status: success`, so nothing alerts the caller — the same failure shape #51 describes.

## Why the fallback fires at all

`_create_session` reads `metadata["project_path"]`, but **no caller ever populated that key** — not `session_manage_lifecycle` (whose signature and MCP schema both lacked the parameter), and neither `_create_session` call inside `_resolve_session_context`. So every created session stored the `"_unknown_"` sentinel, and a session with a sentinel path can never match the `WHERE project_path=$1` lookup. The correct session is unfindable, which is what forces the fallback.

## Changes

**A — stop losing `project_path`**
- thread `project_path` through `_resolve_session_context` into `_create_session`, covering both session-creating branches
- add `project_path` to `session_manage_lifecycle` and its MCP schema
- **absolute paths only**: a relative path resolves against the *server's* cwd, not the caller's. Under the systemd deployment that cwd is this checkout, so deriving from a relative path would misattribute every caller's row to `session-intelligence` — exactly the #48/#49 bug

**B — demand a scope**
- `session_log_decision` now raises `SessionContextRequiredError` on an unbound call, matching what `session_log_learning` already did. The two tools previously disagreed on their own contract
- the check sits *after* the `project_path` → `project_name` derivation, so a caller supplying only `project_path` still resolves

## ⚠️ Contract change

This **reverses** the in-process guard from the #48/#52/#53 lineage. `tests/unit/test_pre_resolver_guard.py` tested the old behaviour deliberately and its docstring called it the *"Happy path"* — that test is rewritten to assert the new contract and to record why the old premise was unsound, rather than deleted.

Migration for callers: pass the `session_id` that `create` returned, or `project_name`. `allow_unbound=True` remains the explicit escape hatch. Six call sites updated; **no `allow_unbound=True` was added anywhere**, since that would re-hide the bug.

The other three tests in that file (stale-disk leak, explicit `project_name` override, explicit `session_id` override) are untouched and still pass.

## Testing

New `tests/regression/test_issue_72_project_session_binding.py` — 8 tests in 3 classes: unbound rejection (including after an in-process create), the `allow_unbound` escape hatch, `project_path` recording (absolute stored / relative ignored / omitted → sentinel), and cross-project binding on **one shared engine**.

That last class is the gap that let this ship: every pre-existing resolver test built a *fresh* engine per test, so none could reproduce cross-project bleed.

```
535 passed, 74 skipped, 1 xfailed in 104.66s
```

Baseline 527 — so +8 new tests, zero regressions. `pixi run --environment ci lint` passes.

## Not fixed here

- **#74** (filed from this work) — `session_track_file_operation` does `list(self.session_cache.keys())[-1]`, the same bug class with *no* gate at all. Third call site
- **#69** — with an explicit `project_name`, `find_recent_session_by_project(..., status="active")` still binds to stale `active` rows: right project, wrong session. Observed during this work. Out of the agreed scope
- de-singletoning the shared engine — the architectural root, deliberately deferred

## Notes for the reviewer

- `closes #72` will **not** auto-close the issue: this PR targets `development`, not the repo default branch
- takes effect only after `systemctl --user restart session-intelligence` — the service runs directly out of the git working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)