### PR TITLE
fix(session): scope file operations to the caller, not the last cache key (closes #74)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -1432,14 +1432,76 @@ class SessionIntelligenceEngine:
         operation: str,
         file_path: str,
         session_id: str | None = None,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
         lines_added: int = 0,
         lines_removed: int = 0,
         summary: str | None = None,
         tool_name: str | None = None,
+        allow_unbound: bool = False,
     ) -> dict[str, Any]:
-        """Track a file operation for the session notebook."""
-        if not session_id and self.session_cache:
-            session_id = list(self.session_cache.keys())[-1]
+        """Track a file operation for the session notebook.
+
+        Pass at least one of session_id, session_name, project_name, or
+        project_path.
+        Use allow_unbound=True to opt into the legacy unbound fallback
+        (deprecated).
+        """
+        # No explicit session identifier: try to derive a project_name from a
+        # caller-supplied project_path before falling back to anything ambient.
+        # Same two guards as session_log_decision and session_log_learning: a
+        # relative project_path is rejected because derive_project_name()
+        # resolves it against the SERVER's cwd -- under the systemd deployment
+        # that is this checkout, so a relative path would misattribute every
+        # caller's row to "session-intelligence" (bug #48/#49) -- and a derived
+        # UNBOUND result is discarded rather than used.
+        if (
+            not (session_id or session_name or project_name)
+            and not allow_unbound
+            and project_path
+            and project_path != UNKNOWN_PROJECT_PATH
+            and Path(project_path).is_absolute()
+        ):
+            derived_name = derive_project_name(project_path)
+            if derived_name != UNBOUND:
+                project_name = derived_name
+
+        # This used to be `session_id = list(self.session_cache.keys())[-1]`:
+        # whatever sat last in dict insertion order won, with no project check
+        # at all. That is weaker even than the guard #72 removed, which at
+        # least required that SOME session had been created in-process. The
+        # HTTP transport builds a SINGLE engine shared by every project
+        # (http_server.py lifespan()), so session_cache is cross-project state
+        # and its last key belongs to whichever project most recently created a
+        # session -- not the caller. Demand a scope instead, exactly as
+        # session_log_decision and session_log_learning now do. Issue #74.
+        if not (session_id or session_name or project_name) and not allow_unbound:
+            raise SessionContextRequiredError(
+                "session_track_file_operation requires at least one of: "
+                "session_id, session_name, project_name. "
+                "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+            )
+
+        # Resolve session via the flexible resolver, so all three tools share
+        # one resolution path instead of reaching into session_cache directly.
+        resolved = await self._resolve_session_context(
+            session_id=session_id,
+            session_name=session_name,
+            project_name=project_name,
+            allow_unbound=allow_unbound,
+            project_path=project_path,
+        )
+        resolved_id = resolved.session_id
+        # Persist newly-created session to DB if needed
+        if resolved_id and resolved_id != session_id:
+            cached = self.session_cache.get(resolved_id)
+            if cached and self.database:
+                try:
+                    await self.database.save_session(cached.model_dump(mode="python"))
+                except Exception:
+                    pass  # Best-effort
+        session_id = resolved_id
 
         if not session_id:
             return {"status": "error", "message": "No active session"}

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -250,7 +250,10 @@ class LeanMCPInterface:
             "implementation": self._wrap_async_tool(
                 self.session_engine.session_track_file_operation
             ),
-            "description": "Track file create/edit/delete operations for session notebook",
+            "description": (
+                "Track file create/edit/delete operations for session notebook "
+                "(requires a session/project scope)"
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
@@ -272,6 +275,34 @@ class LeanMCPInterface:
                     },
                     "summary": {"type": "string", "description": "Brief description of changes"},
                     "tool_name": {"type": "string", "description": "Tool that made the change"},
+                    "session_id": {
+                        "type": "string",
+                        "description": "Explicit session to attribute the operation to",
+                    },
+                    "session_name": {
+                        "type": "string",
+                        "description": "Session name to resolve against",
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "description": "Project context to bind the operation to",
+                    },
+                    "project_path": {
+                        "type": "string",
+                        "description": (
+                            "Absolute path to the caller's project; a project_name is "
+                            "derived from it. Relative paths are ignored (they would "
+                            "resolve against the server's cwd, not the caller's)."
+                        ),
+                    },
+                    "allow_unbound": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "Opt into the legacy '_unbound_' fallback instead of "
+                            "raising when no scope is supplied (deprecated)."
+                        ),
+                    },
                 },
                 "required": ["operation", "file_path"],
             },

--- a/tests/engine/test_mcp_tool_dispatch.py
+++ b/tests/engine/test_mcp_tool_dispatch.py
@@ -283,7 +283,12 @@ class TestExecuteSessionTrackFileOperation:
         execute = _get_meta_tool(lean_interface, "execute_tool")
         result = await execute(
             "session_track_file_operation",
-            {"operation": "create", "file_path": "src/new_module.py", "lines_added": 10},
+            {
+                    "operation": "create",
+                    "file_path": "src/new_module.py",
+                    "lines_added": 10,
+                    "project_name": "test-project",
+                },
         )
         assert result["status"] == "success"
 

--- a/tests/regression/test_issue_74_file_operation_scope_binding.py
+++ b/tests/regression/test_issue_74_file_operation_scope_binding.py
@@ -1,0 +1,307 @@
+"""
+Regression tests for issue #74: unbound file operations silently bound to
+whichever project most recently created a session in the shared engine.
+
+Bug: session_track_file_operation used to pick its session with
+     `session_id = list(self.session_cache.keys())[-1]` -- the last key in
+     dict insertion order, with no project check at all. That is weaker even
+     than the ambient-session fallback issue #72 removed from
+     session_log_decision, which at least required that SOME session had
+     been created in-process. The HTTP transport builds a SINGLE
+     SessionIntelligenceEngine shared by every project (see
+     http_server.py lifespan()), so session_cache is cross-project state and
+     its last key belongs to whichever project most recently created a
+     session in the process -- not the caller. A file op from project A
+     could get recorded against project B's session.
+Fix: session_track_file_operation now raises SessionContextRequiredError
+     when none of session_id/session_name/project_name is supplied (unless
+     allow_unbound=True is explicitly passed), and resolves scope through
+     the same _resolve_session_context() path as session_log_decision and
+     session_log_learning, instead of reaching into session_cache directly.
+"""
+
+import sqlite3
+
+import pytest
+
+from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine
+from persistence.sqlite import SQLiteBackend
+
+
+@pytest.mark.regression
+class TestUnboundFileOperationIsRejected:
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_unbound_file_operation_raises(self, engine):
+        """The core #74 regression: an in-process session existing somewhere
+        in session_cache must NOT silently satisfy an unscoped
+        session_track_file_operation call."""
+        create_result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+        assert create_result.status == "success", (
+            "Precondition failed: session_manage_lifecycle(create) did not "
+            "succeed, so this test cannot exercise the #74 last-cache-key "
+            "bleed scenario."
+        )
+
+        with pytest.raises(SessionContextRequiredError) as exc_info:
+            await engine.session_track_file_operation(
+                operation="edit", file_path="/tmp/x.py"
+            )
+        assert "session_track_file_operation" in str(exc_info.value), (
+            "The #74 regression message should identify "
+            "session_track_file_operation as requiring an explicit scope, "
+            "not silently fall back to the last session_cache key."
+        )
+
+    async def test_allow_unbound_escape_hatch_still_works(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        result = await engine.session_track_file_operation(
+            operation="edit",
+            file_path="/tmp/x.py",
+            allow_unbound=True,
+        )
+        assert result is not None, (
+            "allow_unbound=True is the documented escape hatch for the #74 "
+            "guard and must still permit an unscoped file operation."
+        )
+
+    async def test_relative_project_path_alone_still_raises(self, engine):
+        """A relative project_path resolves against the SERVER's cwd, not
+        the caller's, so it must not silently satisfy scope (#48/#49)."""
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        with pytest.raises(SessionContextRequiredError):
+            await engine.session_track_file_operation(
+                operation="edit",
+                file_path="/tmp/x.py",
+                project_path="relative/proj-a",
+            )
+
+
+@pytest.mark.regression
+class TestSharedEngineDoesNotBleedAcrossProjects:
+    """Every pre-#72 resolver test built a FRESH engine per test, which is
+    exactly why this bug class (#72, and now #74) kept shipping: the HTTP
+    transport builds ONE engine shared across all projects. These tests
+    reuse a single engine for two different projects, with proj-b created
+    SECOND so it is the last key in session_cache -- the value the old
+    buggy `list(session_cache.keys())[-1]` code would have picked."""
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_file_operation_binds_to_named_project_not_last_cache_key(
+        self, engine, tmp_path
+    ):
+        proj_a_path = str(tmp_path / "proj-a")
+        proj_b_path = str(tmp_path / "proj-b")
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=proj_a_path,
+        )
+        # proj-b is created SECOND, i.e. it is the last key in
+        # session_cache when the file operation below is tracked.
+        proj_b_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=proj_b_path,
+        )
+
+        cache_keys = list(engine.session_cache.keys())
+        assert cache_keys[-1] == proj_b_create.session_id, (
+            "Precondition failed: proj-b's session is not the last key in "
+            "session_cache, so this test would not actually exercise the "
+            "#74 last-cache-key bug even if the fix were reverted."
+        )
+
+        result = await engine.session_track_file_operation(
+            operation="edit",
+            file_path="/tmp/x.py",
+            project_name="proj-a",
+        )
+
+        assert result["session_id"] == proj_a_create.session_id, (
+            "Issue #74: the file operation resolved to the wrong session. "
+            "It must bind to proj-a's session (the caller's project_name), "
+            "not fall back to the last key in session_cache."
+        )
+        assert result["session_id"] != proj_b_create.session_id, (
+            "Issue #74: binding this file operation to proj-b's session "
+            "means the last-cache-key fallback is back -- proj-b was only "
+            "created more recently, it was never named by the caller."
+        )
+
+    async def test_file_operation_binds_by_absolute_project_path(
+        self, engine, tmp_path
+    ):
+        # derive_project_name() probes path.is_dir() and otherwise falls
+        # back to path.parent (both proj-a and proj-b would then resolve
+        # to tmp_path's own basename, collapsing the two projects into the
+        # same derived name). The directories must exist on disk so each
+        # path derives its own distinct project name, matching how a real
+        # caller's cwd always exists.
+        proj_a_dir = tmp_path / "proj-a"
+        proj_a_dir.mkdir()
+        proj_b_dir = tmp_path / "proj-b"
+        proj_b_dir.mkdir()
+        proj_a_path = str(proj_a_dir)
+        proj_b_path = str(proj_b_dir)
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=proj_a_path,
+        )
+        proj_b_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=proj_b_path,
+        )
+
+        result = await engine.session_track_file_operation(
+            operation="edit",
+            file_path="/tmp/x.py",
+            project_path=proj_a_path,
+        )
+
+        assert result["session_id"] == proj_a_create.session_id, (
+            "Issue #74: an absolute project_path naming proj-a must derive "
+            "proj-a's project_name and bind to proj-a's session, not to "
+            "proj-b's merely because proj-b was created more recently."
+        )
+        assert result["session_id"] != proj_b_create.session_id
+
+    async def test_explicit_session_id_wins_over_last_cache_key(
+        self, engine, tmp_path
+    ):
+        proj_a_path = str(tmp_path / "proj-a")
+        proj_b_path = str(tmp_path / "proj-b")
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=proj_a_path,
+        )
+        proj_b_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=proj_b_path,
+        )
+
+        result = await engine.session_track_file_operation(
+            operation="edit",
+            file_path="/tmp/x.py",
+            session_id=proj_a_create.session_id,
+        )
+
+        assert result["session_id"] == proj_a_create.session_id, (
+            "Issue #74: an explicit session_id must be honored even though "
+            "proj-b's session sits last in session_cache."
+        )
+        assert result["session_id"] != proj_b_create.session_id
+
+
+@pytest.mark.regression
+class TestFileOperationIsPersistedUnderResolvedSession:
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path))
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_row_is_written_under_the_resolved_session(
+        self, engine, tmp_path
+    ):
+        """SQLiteBackend.query_file_operations_by_session() exists (see
+        src/persistence/sqlite.py), so this test uses that getter directly
+        rather than a raw SQL SELECT."""
+        proj_a_path = str(tmp_path / "proj-a")
+        proj_b_path = str(tmp_path / "proj-b")
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=proj_a_path,
+        )
+        proj_b_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=proj_b_path,
+        )
+
+        result = await engine.session_track_file_operation(
+            operation="edit",
+            file_path="/tmp/x.py",
+            project_name="proj-a",
+        )
+        assert result["status"] == "success"
+
+        proj_a_rows = await engine.database.query_file_operations_by_session(
+            proj_a_create.session_id
+        )
+        assert len(proj_a_rows) == 1, (
+            "Issue #74: the file operation row should be persisted under "
+            "proj-a's session_id in the file_operations table, but "
+            f"query_file_operations_by_session(proj-a) returned "
+            f"{len(proj_a_rows)} rows instead of 1."
+        )
+        assert proj_a_rows[0]["file_path"] == "/tmp/x.py"
+
+        proj_b_rows = await engine.database.query_file_operations_by_session(
+            proj_b_create.session_id
+        )
+        assert proj_b_rows == [], (
+            "Issue #74: the file operation must not be persisted under "
+            "proj-b's session_id -- that would mean the row was written "
+            "under the last-created session instead of the caller's "
+            "named project_name."
+        )
+
+        # Cross-check with a raw SQL SELECT against the underlying SQLite
+        # file directly, independent of the getter above.
+        db_path = str(tmp_path / "test.db")
+        conn = sqlite3.connect(db_path)
+        try:
+            cursor = conn.execute(
+                "SELECT session_id, file_path FROM file_operations"
+            )
+            raw_rows = cursor.fetchall()
+        finally:
+            conn.close()
+        assert raw_rows == [(proj_a_create.session_id, "/tmp/x.py")], (
+            "Issue #74: a raw SQL SELECT against file_operations confirms "
+            f"the persisted row(s) {raw_rows!r} must reference only "
+            "proj-a's session_id, not proj-b's."
+        )


### PR DESCRIPTION
Closes #74.

## The bug

`session_track_file_operation` picked its session with:

```python
session_id = list(self.session_cache.keys())[-1]
```

Whatever sat last in dict insertion order won, with **no project check at all**. `http_server.py` `lifespan()` builds a single `SessionIntelligenceEngine` shared across every project's requests, so `session_cache` is cross-project state — a file operation from project A was recorded against project B's session whenever B's session happened to be inserted last.

This is the third call site of the bug class #72 documented, and the weakest of the three. `session_log_decision`'s fallback was at least gated on `_current_session_set_in_process`, so it required *some* session to have been created in-process. This had no gate whatsoever.

As with #72, the write succeeds and the envelope reports success — nothing signals the misattribution. It is visible only by reading the stored `session_id` back out.

## The fix

- Require a scope: raise `SessionContextRequiredError` when none of `session_id`/`session_name`/`project_name` is supplied and `allow_unbound` is not set, matching `session_log_decision` and `session_log_learning`.
- Add `session_name`/`project_name`/`project_path`/`allow_unbound` parameters. An absolute `project_path` derives a `project_name`; a relative one is ignored, because it would resolve against the **server's** cwd rather than the caller's (the #48/#49 bug).
- Route through `_resolve_session_context` so all three tools share one resolution path instead of reaching into `session_cache` directly.

The MCP schema previously declared neither `session_id` nor any project field, and `validate_tool_parameters` rejects undeclared parameters — so no MCP caller could bind this tool at all. All five parameters are added there too.

## Tests

`tests/regression/test_issue_74_file_operation_scope_binding.py` uses **one** engine across two projects, with `proj-b` created second so it is the last cache key the old code would have chosen. Every pre-#72 resolver test built a fresh engine per test, which is exactly why this class of bug kept shipping.

One note for future test authors: `derive_project_name()` probes `path.is_dir()` and otherwise falls back to `path.parent`, so the project directories must exist on disk or `proj-a` and `proj-b` collapse to the same derived name. Production is unaffected — a caller's cwd always exists.

`540 passed, 74 skipped, 1 xfailed` (baseline 533 passed, plus 7 new). Lint gate clean.

## Deployment note — read before merging

`~/.claude/hooks/session_intelligence_post_tool.py` calls this tool on every `Write`/`Edit`/`Read` with **no scope**, at three call sites. It must be updated to pass `project_name=project_name_for(cwd)` (the idiom it already uses for `session_log_learning`) — but only **after** this merges and the service restarts, because `validate_tool_parameters` is strict and would reject the new parameters against the old schema.

Correct order: **merge → `systemctl --user restart session-intelligence` → update the hook.**

In the window between restart and hook update, unscoped calls raise and the operation is simply not recorded. The hook discards return values and swallows errors, so no session breaks — only file-operation telemetry pauses.

## Related

- #72 — same bug class; fixed the `session_log_decision` site and added the shared-engine test harness reused here
- #69 — stale `active` sessions enlarge the pool of wrong sessions these fallbacks can select
- The second site in #74's table, `_ensure_sessions_loaded_from_database`, remains open and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)