### PR TITLE
fix(tools): unregister session_orchestrate_workflow from BOTH interfaces (closes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unified session management and analytics MCP server for the Claude Code framewor
 
 ## Overview
 
-This MCP server consolidates **42+ scattered claudecode session management functions** into **10 unified MCP functions**, providing comprehensive session lifecycle management, execution tracking, decision logging, pattern analysis, and intelligence operations.
+This MCP server consolidates **42+ scattered claudecode session management functions** into **9 unified MCP functions**, providing comprehensive session lifecycle management, execution tracking, decision logging, pattern analysis, and intelligence operations.
 
 ## Features
 
@@ -62,24 +62,18 @@ Real-time session health monitoring with auto-recovery capabilities.
 - **Features**: Auto-recovery, diagnostics, alert thresholds
 - **Monitoring**: Health scores, issue detection, recovery actions
 
-### 7. `session_orchestrate_workflow`
-Advanced workflow orchestration with state management and optimization.
-- **Types**: tdd, atomic, quality, prime, custom
-- **Features**: State machines, parallel execution, optimization algorithms
-- **Management**: Phase tracking, progress monitoring, next steps
-
-### 8. `session_analyze_commands`
+### 7. `session_analyze_commands`
 Analyze hook-based command logs for patterns and inefficiencies.
 - **Analysis**: Command patterns, timing analysis, success rates
 - **Detection**: Inefficient patterns, error analysis, optimization opportunities
 - **Suggestions**: Alternative commands, performance improvements
 
-### 9. `session_track_missing_functions`
+### 8. `session_track_missing_functions`
 Track and analyze missing functions for ecosystem improvement.
 - **Features**: Priority analysis, implementation suggestions, impact assessment
 - **Tracking**: Missing function detection, usage patterns, ecosystem gaps
 
-### 10. `session_get_dashboard`
+### 9. `session_get_dashboard`
 Comprehensive session intelligence dashboard with real-time insights.
 - **Types**: overview, performance, agents, decisions, health
 - **Features**: Real-time updates, visualizations, export formats

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -1653,6 +1653,12 @@ class SessionIntelligenceEngine:
 
     # ===== PLACEHOLDER IMPLEMENTATIONS FOR OTHER FUNCTIONS =====
 
+    # NOTE: Unregistered from the tool registry (src/lean_mcp_interface.py)
+    # per #64 — this hardcodes state_machine={} below, and WorkflowState
+    # .state_machine requires a StateMachine with a required current_state
+    # field, so every call raises a pydantic ValidationError. Left in place
+    # as dead code pending a real implementation; do not re-register
+    # without fixing this.
     def session_orchestrate_workflow(self, **kwargs) -> WorkflowResult:
         """Workflow orchestration - placeholder implementation."""
         return WorkflowResult(

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -384,34 +384,12 @@ class LeanMCPInterface:
             ],
         }
 
-        registry["session_orchestrate_workflow"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_orchestrate_workflow),
-            "description": "Advanced workflow orchestration with optimization",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "workflow_type": {
-                        "type": "string",
-                        "enum": ["tdd", "atomic", "quality", "prime", "custom"],
-                        "description": "Workflow type",
-                    },
-                    "session_id": {"type": "string", "description": "Session context"},
-                    "workflow_config": {"type": "object", "description": "Workflow configuration"},
-                    "parallel_execution": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": "Enable parallel execution",
-                    },
-                    "optimize_execution": {
-                        "type": "boolean",
-                        "default": True,
-                        "description": "Optimize execution order",
-                    },
-                },
-                "required": ["workflow_type"],
-            },
-            "examples": [{"workflow_type": "tdd", "parallel_execution": True}],
-        }
+        # session_orchestrate_workflow is intentionally NOT registered here.
+        # session_engine.session_orchestrate_workflow() hardcodes
+        # state_machine={} inside WorkflowState(...), and StateMachine
+        # requires current_state: str with no default, so every call
+        # raises a pydantic ValidationError. Unregistered per #64 pending
+        # a real implementation.
 
         registry["session_analyze_commands"] = {
             "implementation": self._wrap_tool(self.session_engine.session_analyze_commands),

--- a/src/session/server.py
+++ b/src/session/server.py
@@ -33,8 +33,6 @@ from models.session_models import (
     PatternAnalysisResult,
     SessionHealthResult,
     SessionResult,
-    WorkflowResult,
-    WorkflowType,
 )
 from utils.token_limiter import apply_token_limits
 
@@ -387,48 +385,12 @@ def session_monitor_health(
         )
 
 
-@app.tool()
-def session_orchestrate_workflow(
-    workflow_type: str,
-    session_id: str | None = None,
-    workflow_config: dict[str, Any] | None = None,
-    parallel_execution: bool = False,
-    optimize_execution: bool = True,
-) -> dict[str, Any]:
-    """
-    Advanced workflow orchestration with state management and optimization.
-
-    Consolidates: claudecode_workflow_init, claudecode_workflow_status,
-                 claudecode_workflow_complete, claudecode_workflow_orchestrate_prime
-
-    Args:
-        workflow_type: Workflow type ("tdd", "atomic", "quality", "prime", "custom")
-        session_id: Session context (optional)
-        workflow_config: Workflow configuration (optional)
-        parallel_execution: Enable parallel execution (default: False)
-        optimize_execution: Optimize execution order (default: True)
-
-    Returns:
-        WorkflowResult with execution plan, state, progress, optimizations
-    """
-    try:
-        wf_type = WorkflowType(workflow_type)
-
-        result = session_engine.session_orchestrate_workflow(
-            workflow_type=wf_type,
-            session_id=session_id,
-            workflow_config=workflow_config,
-            parallel_execution=parallel_execution,
-            optimize_execution=optimize_execution,
-        )
-        return safe_response(result, "session_manage_lifecycle")
-    except Exception as e:
-        return WorkflowResult(
-            workflow_id="error",
-            session_id=session_id or "unknown",
-            execution_plan={"error": str(e)},
-            state=None,
-        )
+# session_orchestrate_workflow is intentionally NOT registered here.
+# session_engine.session_orchestrate_workflow() hardcodes
+# state_machine={} inside WorkflowState(...), and StateMachine
+# requires current_state: str with no default, so every call
+# raises a pydantic ValidationError. Unregistered per #64 pending
+# a real implementation.
 
 
 @app.tool()

--- a/tests/engine/test_mcp_tool_dispatch.py
+++ b/tests/engine/test_mcp_tool_dispatch.py
@@ -309,21 +309,32 @@ class TestExecuteSessionMonitorHealth:
         assert result["status"] == "success"
 
 
-class TestExecuteSessionOrchestrateWorkflow:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="session_orchestrate_workflow is a placeholder that builds an invalid "
-               "WorkflowState; registered but non-functional. Tracked separately - see "
-               "issue #64 in the PR body.",
-    )
-    async def test_execute_session_orchestrate_workflow(self, lean_interface):
-        """session_orchestrate_workflow succeeds with a valid workflow_type."""
+class TestSessionOrchestrateWorkflowUnregistered:
+    """session_orchestrate_workflow is intentionally unregistered (#64).
+
+    The underlying engine method hardcodes state_machine={} inside
+    WorkflowState(...), and WorkflowState.state_machine is a required
+    StateMachine (whose current_state: str has no default), so every
+    call would raise a pydantic ValidationError. Rather than expose a
+    tool that can never succeed, it was removed from the registry.
+    """
+
+    async def test_not_advertised_by_discover_tools(self, lean_interface):
+        discover = _get_meta_tool(lean_interface, "discover_tools")
+        result = discover("")
+        tool_names = {tool["name"] for tool in result["available_tools"]}
+        assert "session_orchestrate_workflow" not in tool_names
+
+    async def test_execute_returns_tool_not_found(self, lean_interface):
         execute = _get_meta_tool(lean_interface, "execute_tool")
         result = await execute(
             "session_orchestrate_workflow",
             {"workflow_type": "tdd"},
         )
-        assert result["status"] == "success"
+        assert result == {
+            "error": "Tool 'session_orchestrate_workflow' not found",
+            "available_tools": list(lean_interface.tool_registry.keys()),
+        }
 
 
 class TestExecuteSessionAnalyzeCommands:


### PR DESCRIPTION
## Summary

`session_orchestrate_workflow` was registered and advertised by `discover_tools`, but every call raised a pydantic `ValidationError`: the engine hardcodes `state_machine={}` inside `WorkflowState(...)`, and `WorkflowState.state_machine` is a required `StateMachine` whose `current_state: str` has no default. No caller input could avoid it — the empty dict is hardcoded, not caller-supplied.

Per the issue's own framing, a tool that always fails is worse than a tool that is not offered, so it is unregistered rather than papered over with a valid placeholder.

## Dual-interface point

This repo maintains a dual interface. The lean interface (`src/lean_mcp_interface.py`) had already been fixed in a prior pass. This PR completes the fix by unregistering the tool from `src/session/server.py` (the "traditional" server) as well, since it registers the same tool and delegates to the same broken engine method (line ~417 pre-change). Shipping only the lean-side change would have meant a PR claiming "closes #64" while the traditional server still advertised a tool that cannot succeed.

## Audit

Audited the other four methods under the PLACEHOLDER banner (`session_analyze_patterns`, `session_analyze_commands`, `session_track_missing_functions`, `session_get_dashboard`): all pass `{}`/`[]` to plain dict/list fields with `default_factory` and validate fine. Only `session_orchestrate_workflow` was unsatisfiable.

The engine method (`session_engine.session_orchestrate_workflow`) is left in place as dead code with a comment warning against re-registering it unfixed.

## Changes

- `src/lean_mcp_interface.py` — registry entry removed (prior pass), replaced by explanatory comment referencing #64
- `src/core/session_engine.py` — comment added above the method; body deliberately unchanged
- `src/session/server.py` — tool registration/handler removed, unused `WorkflowResult`/`WorkflowType` imports removed, explanatory comment added
- `tests/engine/test_mcp_tool_dispatch.py` — xfail `TestExecuteSessionOrchestrateWorkflow` replaced by `TestSessionOrchestrateWorkflowUnregistered` (2 tests)
- `README.md` — removed tool listing entry, decremented tool count 10 → 9

## Test infrastructure note

No existing test file targets `src/session/server.py` directly (grepped `tests/` for `session.server` imports — none found), so no traditional-server-specific regression test was added per the "do not invent test infra" instruction.

## Verification

- `pytest tests/ -v` (env `ci`): **544 passed, 74 skipped, 0 failed, 0 xfailed** (baseline was 540 passed / 74 skipped / 1 xfailed)
- `pixi run -e ci lint`: **All checks passed!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)