### PR TITLE
fix(session): bind lifecycle, execution and health tools to the caller's scope (closes #77)

### DIFF
--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -498,6 +498,9 @@ class SessionIntelligenceEngine:
         project_path: str | None = None,
         metadata: dict[str, Any] | None = None,
         auto_recovery: bool = True,
+        session_id: str | None = None,
+        session_name: str | None = None,
+        allow_unbound: bool = False,
     ) -> SessionResult:
         """
         Comprehensive session lifecycle management with intelligent tracking.
@@ -508,11 +511,27 @@ class SessionIntelligenceEngine:
             claudecode_finalize_session_summary,
             claudecode_save_session_state,
             claudecode_capture_enhanced_state
+
+        The resume/finalize/validate operations require at least one of
+        session_id, session_name, or project_name (derived from project_path
+        as a last resort). Pass allow_unbound=True to opt into the legacy
+        ambient-session fallback (deprecated). The create operation is
+        unaffected -- project_name/project_path remain optional there.
         """
         try:
             return await self._manage_lifecycle_impl(
-                operation, mode, project_name, project_path, metadata, auto_recovery
+                operation,
+                mode,
+                project_name,
+                project_path,
+                metadata,
+                auto_recovery,
+                session_id=session_id,
+                session_name=session_name,
+                allow_unbound=allow_unbound,
             )
+        except SessionContextRequiredError:
+            raise
         except Exception as e:
             return SessionResult(
                 session_id="error",
@@ -529,8 +548,19 @@ class SessionIntelligenceEngine:
         project_path: str | None,
         metadata: dict[str, Any] | None,
         auto_recovery: bool,
+        session_id: str | None = None,
+        session_name: str | None = None,
+        allow_unbound: bool = False,
     ) -> SessionResult:
-        """Session lifecycle management."""
+        """Session lifecycle management.
+
+        Forwards session_id/session_name/project_name/project_path/
+        allow_unbound into the resume/finalize/validate branches -- issue
+        #77: these used to be dropped here, so a caller-supplied scope
+        (e.g. the Stop hook's project_name) was silently discarded and
+        finalize/resume/validate fell back to ambient session_cache state
+        shared across every project on the HTTP transport.
+        """
 
         if operation == "create":
             create_metadata = dict(metadata or {})
@@ -554,11 +584,30 @@ class SessionIntelligenceEngine:
                     )
             return result
         elif operation == "resume":
-            return self._resume_session(auto_recovery)
+            return await self._resume_session(
+                auto_recovery,
+                session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                project_path=project_path,
+                allow_unbound=allow_unbound,
+            )
         elif operation == "finalize":
-            return await self._finalize_session()
+            return await self._finalize_session(
+                session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                project_path=project_path,
+                allow_unbound=allow_unbound,
+            )
         elif operation == "validate":
-            return self._validate_session()
+            return await self._validate_session(
+                session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                project_path=project_path,
+                allow_unbound=allow_unbound,
+            )
         else:
             return SessionResult(
                 session_id="error",
@@ -640,17 +689,63 @@ class SessionIntelligenceEngine:
             next_steps=["Initialize agent tracking", "Set up workflow state"],
         )
 
-    def _resume_session(self, auto_recovery: bool) -> SessionResult:
-        """Resume an existing session with recovery if needed."""
-        # First check in-memory cache
-        if self.session_cache:
-            session_id = list(self.session_cache.keys())[-1]
-            self._current_session_id = session_id
-            return SessionResult(
+    async def _resume_session(
+        self,
+        auto_recovery: bool,
+        session_id: str | None = None,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
+    ) -> SessionResult:
+        """Resume an existing session with recovery if needed.
+
+        Requires at least one of session_id, session_name, or project_name
+        (or an absolute project_path a project_name can be derived from), or
+        allow_unbound=True. Issue #77: this used to pick
+        `list(self.session_cache.keys())[-1]` -- whichever project last
+        created a session in the shared HTTP-transport engine -- with no
+        scope check at all.
+        """
+        if (
+            not (session_id or session_name or project_name)
+            and not allow_unbound
+            and project_path
+            and project_path != UNKNOWN_PROJECT_PATH
+            and Path(project_path).is_absolute()
+        ):
+            derived_name = derive_project_name(project_path)
+            if derived_name != UNBOUND:
+                project_name = derived_name
+
+        if not (session_id or session_name or project_name) and not allow_unbound:
+            raise SessionContextRequiredError(
+                "session_manage_lifecycle(resume) requires at least one of: "
+                "session_id, session_name, project_name. "
+                "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+            )
+
+        try:
+            resolved = await self._resolve_session_context(
                 session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                allow_unbound=allow_unbound,
+                create_if_missing=False,
+                project_path=project_path,
+            )
+        except ValueError:
+            resolved = None
+
+        # Scoped cache lookup (replaces the ambient last-cache-key pick)
+        if resolved is not None and resolved.session_id in self.session_cache:
+            resumed_id = resolved.session_id
+            self._current_session_id = resumed_id
+            return SessionResult(
+                session_id=resumed_id,
                 operation="resume",
                 status="success",
-                message=f"Resumed session {session_id} from cache",
+                message=f"Resumed session {resumed_id} from cache",
                 recovery_options=(
                     ["Validate continuity", "Check health"]
                     if auto_recovery
@@ -703,7 +798,14 @@ class SessionIntelligenceEngine:
             message="No existing sessions found",
         )
 
-    async def _finalize_session(self) -> SessionResult:
+    async def _finalize_session(
+        self,
+        session_id: str | None = None,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
+    ) -> SessionResult:
         """Finalize current session with comprehensive summary.
 
         Persists status='completed' to the database so that subsequent
@@ -711,9 +813,44 @@ class SessionIntelligenceEngine:
         returning this session, and removes the session from the
         in-memory cache so disk reloads don't resurrect stale state
         (see issue #25).
+
+        Requires at least one of session_id, session_name, or project_name
+        (or an absolute project_path a project_name can be derived from), or
+        allow_unbound=True. Issue #77: this used to resolve the target
+        session via `_get_or_create_current_session_id()`, which is ambient
+        process-wide state -- on the HTTP transport's single shared engine,
+        that could finalize a DIFFERENT project's session than the caller's.
         """
-        # Get current session ID
-        session_id = self._get_or_create_current_session_id()
+        if (
+            not (session_id or session_name or project_name)
+            and not allow_unbound
+            and project_path
+            and project_path != UNKNOWN_PROJECT_PATH
+            and Path(project_path).is_absolute()
+        ):
+            derived_name = derive_project_name(project_path)
+            if derived_name != UNBOUND:
+                project_name = derived_name
+
+        if not (session_id or session_name or project_name) and not allow_unbound:
+            raise SessionContextRequiredError(
+                "session_manage_lifecycle(finalize) requires at least one of: "
+                "session_id, session_name, project_name. "
+                "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+            )
+
+        try:
+            resolved = await self._resolve_session_context(
+                session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                allow_unbound=allow_unbound,
+                create_if_missing=False,
+                project_path=project_path,
+            )
+            session_id = resolved.session_id
+        except ValueError:
+            session_id = None
 
         if not session_id or session_id not in self.session_cache:
             return SessionResult(
@@ -782,9 +919,52 @@ class SessionIntelligenceEngine:
             session_data=session,
         )
 
-    def _validate_session(self) -> SessionResult:
-        """Validate session continuity and health."""
-        if not self.session_cache:
+    async def _validate_session(
+        self,
+        session_id: str | None = None,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
+    ) -> SessionResult:
+        """Validate session continuity and health.
+
+        Requires at least one of session_id, session_name, or project_name
+        (or an absolute project_path a project_name can be derived from), or
+        allow_unbound=True. Issue #77: this used to pick
+        `list(self.session_cache.keys())[-1]` with no scope check.
+        """
+        if (
+            not (session_id or session_name or project_name)
+            and not allow_unbound
+            and project_path
+            and project_path != UNKNOWN_PROJECT_PATH
+            and Path(project_path).is_absolute()
+        ):
+            derived_name = derive_project_name(project_path)
+            if derived_name != UNBOUND:
+                project_name = derived_name
+
+        if not (session_id or session_name or project_name) and not allow_unbound:
+            raise SessionContextRequiredError(
+                "session_manage_lifecycle(validate) requires at least one of: "
+                "session_id, session_name, project_name. "
+                "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+            )
+
+        try:
+            resolved = await self._resolve_session_context(
+                session_id=session_id,
+                session_name=session_name,
+                project_name=project_name,
+                allow_unbound=allow_unbound,
+                create_if_missing=False,
+                project_path=project_path,
+            )
+        except ValueError:
+            resolved = None
+
+        if resolved is None or resolved.session_id not in self.session_cache:
             return SessionResult(
                 session_id="none",
                 operation="validate",
@@ -792,7 +972,7 @@ class SessionIntelligenceEngine:
                 message="No active session to validate",
             )
 
-        session_id = list(self.session_cache.keys())[-1]
+        session_id = resolved.session_id
         session = self.session_cache[session_id]
 
         # Perform validation checks
@@ -829,13 +1009,17 @@ class SessionIntelligenceEngine:
 
     # ===== EXECUTION TRACKING =====
 
-    def session_track_execution(
+    async def session_track_execution(
         self,
         session_id: str | None,
         agent_name: str,
         step_data: dict[str, Any],
         track_patterns: bool = True,
         suggest_optimizations: bool = True,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
     ) -> ExecutionTrackingResult:
         """
         Advanced execution tracking with pattern detection and optimization.
@@ -845,12 +1029,22 @@ class SessionIntelligenceEngine:
             claudecode_log_execution_step,
             claudecode_write_agent_execution_log,
             claudecode_update_agent_status
+
+        When session_id is omitted, at least one of session_name or
+        project_name (or an absolute project_path) is required, unless
+        allow_unbound=True opts into the legacy ambient-session fallback.
+        A caller-supplied session_id that isn't yet cached (e.g. a hook's
+        native Claude Code session UUID) is still auto-bound regardless of
+        scope -- that path is unaffected by this guard.
         """
         try:
-            return self._track_execution_sync(
+            return await self._track_execution_sync(
                 session_id, agent_name, step_data, track_patterns,
-                suggest_optimizations
+                suggest_optimizations, session_name, project_name,
+                project_path, allow_unbound,
             )
+        except SessionContextRequiredError:
+            raise
         except Exception:
             return ExecutionTrackingResult(
                 step_id="error",
@@ -861,15 +1055,21 @@ class SessionIntelligenceEngine:
                 optimizations=[],
             )
 
-    def _track_execution_sync(
+    async def _track_execution_sync(
         self,
         session_id: str | None,
         agent_name: str,
         step_data: dict[str, Any],
         track_patterns: bool,
         suggest_optimizations: bool,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
     ) -> ExecutionTrackingResult:
-        """Synchronous execution tracking."""
+        """Execution tracking (retains the `_sync` name for continuity with
+        existing call sites/tests; issue #77 made it async so it can resolve
+        scope through `_resolve_session_context()`)."""
 
         debug_logger.info("_track_execution_sync called")
         debug_logger.info(f"session_id: {session_id}")
@@ -880,10 +1080,37 @@ class SessionIntelligenceEngine:
             f"session_cache keys: {list(self.session_cache.keys())}"
         )
 
-        # Get current session ID (auto-detect from file if not provided)
+        # No explicit session_id: resolve scope instead of falling back to
+        # ambient `_current_session_id` state, which is shared across every
+        # project on the HTTP transport's single engine (issue #77).
         if not session_id:
-            session_id = self._get_or_create_current_session_id()
-            debug_logger.info(f"Auto-detected session_id: {session_id}")
+            if (
+                not (session_name or project_name)
+                and not allow_unbound
+                and project_path
+                and project_path != UNKNOWN_PROJECT_PATH
+                and Path(project_path).is_absolute()
+            ):
+                derived_name = derive_project_name(project_path)
+                if derived_name != UNBOUND:
+                    project_name = derived_name
+
+            if not (session_name or project_name) and not allow_unbound:
+                raise SessionContextRequiredError(
+                    "session_track_execution requires at least one of: "
+                    "session_id, session_name, project_name. "
+                    "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+                )
+
+            resolved = await self._resolve_session_context(
+                session_id=None,
+                session_name=session_name,
+                project_name=project_name,
+                allow_unbound=allow_unbound,
+                project_path=project_path,
+            )
+            session_id = resolved.session_id
+            debug_logger.info(f"Resolved session_id: {session_id}")
 
         if not session_id:
             debug_logger.error(
@@ -1529,13 +1756,17 @@ class SessionIntelligenceEngine:
 
     # ===== HEALTH MONITORING =====
 
-    def session_monitor_health(
+    async def session_monitor_health(
         self,
         session_id: str | None,
         health_checks: list[str] = None,
         auto_recover: bool = True,
         alert_thresholds: dict[str, float] | None = None,
         include_diagnostics: bool = True,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
     ) -> SessionHealthResult:
         """
         Real-time session health monitoring with auto-recovery capabilities.
@@ -1544,15 +1775,22 @@ class SessionIntelligenceEngine:
             claudecode_validate_session_files,
             claudecode_session_continuity_check,
             claudecode_meta_session_health
+
+        When session_id is None/omitted, at least one of session_name or
+        project_name (or an absolute project_path) is required, unless
+        allow_unbound=True opts into the legacy ambient-session fallback.
         """
         if health_checks is None:
             health_checks = ["continuity", "files", "state", "agents"]
 
         try:
-            return self._monitor_health_sync(
+            return await self._monitor_health_sync(
                 session_id, health_checks, auto_recover,
-                alert_thresholds, include_diagnostics
+                alert_thresholds, include_diagnostics,
+                session_name, project_name, project_path, allow_unbound,
             )
+        except SessionContextRequiredError:
+            raise
         except Exception as e:
             return SessionHealthResult(
                 session_id=session_id or "unknown",
@@ -1560,19 +1798,55 @@ class SessionIntelligenceEngine:
                 issues=[f"Health monitoring error: {str(e)}"],
             )
 
-    def _monitor_health_sync(
+    async def _monitor_health_sync(
         self,
         session_id: str | None,
         health_checks: list[str],
         auto_recover: bool,
         alert_thresholds: dict[str, float] | None,
         include_diagnostics: bool,
+        session_name: str | None = None,
+        project_name: str | None = None,
+        project_path: str | None = None,
+        allow_unbound: bool = False,
     ) -> SessionHealthResult:
-        """Synchronous health monitoring."""
+        """Health monitoring (retains the `_sync` name for continuity with
+        existing call sites/tests; issue #77 made it async so it can resolve
+        scope through `_resolve_session_context()`)."""
 
-        # Get current session
-        if not session_id and self.session_cache:
-            session_id = list(self.session_cache.keys())[-1]
+        # Get current session, scoped -- replaces the ambient
+        # `list(self.session_cache.keys())[-1]` pick (issue #77).
+        if not session_id:
+            if (
+                not (session_name or project_name)
+                and not allow_unbound
+                and project_path
+                and project_path != UNKNOWN_PROJECT_PATH
+                and Path(project_path).is_absolute()
+            ):
+                derived_name = derive_project_name(project_path)
+                if derived_name != UNBOUND:
+                    project_name = derived_name
+
+            if not (session_name or project_name) and not allow_unbound:
+                raise SessionContextRequiredError(
+                    "session_monitor_health requires at least one of: "
+                    "session_id, session_name, project_name. "
+                    "(Pass allow_unbound=True to opt into the legacy '_unbound_' fallback.)"
+                )
+
+            try:
+                resolved = await self._resolve_session_context(
+                    session_id=None,
+                    session_name=session_name,
+                    project_name=project_name,
+                    allow_unbound=allow_unbound,
+                    create_if_missing=False,
+                    project_path=project_path,
+                )
+                session_id = resolved.session_id
+            except ValueError:
+                session_id = None
 
         if not session_id or session_id not in self.session_cache:
             return SessionHealthResult(
@@ -2032,11 +2306,22 @@ class SessionIntelligenceEngine:
     ) -> NotebookResult:
         """Notebook creation with proper async database access."""
 
-        # Get session (current or specified)
+        # Both callers (session_create_notebook / session_create_notebook_async)
+        # already resolve session_id via _resolve_session_context() before
+        # reaching this helper, so this is defensive: there is no
+        # session_name/project_name/project_path here to derive a scope
+        # from, so a missing session_id can only be rejected, not resolved
+        # ambiently. Issue #77: replaces the latent
+        # `_get_or_create_current_session_id()` ambient fallback that used
+        # to sit here.
         if not session_id:
-            session_id = self._get_or_create_current_session_id()
+            raise SessionContextRequiredError(
+                "_create_notebook_impl requires a resolved session_id; "
+                "callers must resolve session_id via _resolve_session_context "
+                "before calling (no ambient session fallback is available here)."
+            )
 
-        if not session_id or session_id not in self.session_cache:
+        if session_id not in self.session_cache:
             return NotebookResult(
                 session_id=session_id or "unknown",
                 status="error",

--- a/src/lean_mcp_interface.py
+++ b/src/lean_mcp_interface.py
@@ -95,17 +95,41 @@ class LeanMCPInterface:
                         "default": True,
                         "description": "Enable automatic recovery",
                     },
+                    "session_id": {
+                        "type": "string",
+                        "description": (
+                            "Explicit session to resume/finalize/validate. "
+                            "Required (with session_name/project_name as alternatives) "
+                            "for operations other than 'create'."
+                        ),
+                    },
+                    "session_name": {
+                        "type": "string",
+                        "description": (
+                            "Session name to resolve against for resume/finalize/validate."
+                        ),
+                    },
+                    "allow_unbound": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "For resume/finalize/validate: opt into the legacy "
+                            "'_unbound_' ambient-session fallback instead of raising "
+                            "when no scope is supplied (deprecated)."
+                        ),
+                    },
                 },
                 "required": ["operation"],
             },
             "examples": [
                 {"operation": "create", "project_name": "my-project"},
-                {"operation": "resume", "mode": "hybrid"},
+                {"operation": "resume", "mode": "hybrid", "project_name": "my-project"},
+                {"operation": "finalize", "project_name": "my-project"},
             ],
         }
 
         registry["session_track_execution"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_track_execution),
+            "implementation": self._wrap_async_tool(self.session_engine.session_track_execution),
             "description": "Track agent execution with pattern detection",
             "schema": {
                 "type": "object",
@@ -122,6 +146,36 @@ class LeanMCPInterface:
                         "type": "boolean",
                         "default": True,
                         "description": "Generate optimization suggestions",
+                    },
+                    "session_name": {
+                        "type": "string",
+                        "description": (
+                            "Session name to resolve against when session_id is omitted."
+                        ),
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "description": (
+                            "Project context to bind the execution step to when "
+                            "session_id is omitted."
+                        ),
+                    },
+                    "project_path": {
+                        "type": "string",
+                        "description": (
+                            "Absolute path to the caller's project; a project_name is "
+                            "derived from it when session_id is omitted. Relative paths "
+                            "are ignored."
+                        ),
+                    },
+                    "allow_unbound": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "Opt into the legacy '_unbound_' ambient-session fallback "
+                            "instead of raising when session_id is omitted and no other "
+                            "scope is supplied (deprecated)."
+                        ),
                     },
                 },
                 "required": ["agent_name", "step_data"],
@@ -347,14 +401,20 @@ class LeanMCPInterface:
         }
 
         registry["session_monitor_health"] = {
-            "implementation": self._wrap_tool(self.session_engine.session_monitor_health),
-            "description": "Real-time session health monitoring with auto-recovery",
+            "implementation": self._wrap_async_tool(self.session_engine.session_monitor_health),
+            "description": (
+                "Real-time session health monitoring with auto-recovery "
+                "(requires a session/project scope when session_id is null)"
+            ),
             "schema": {
                 "type": "object",
                 "properties": {
                     "session_id": {
                         "type": ["string", "null"],
-                        "description": "Session to monitor (use null for current session)",
+                        "description": (
+                            "Session to monitor. If null, session_name or "
+                            "project_name (or allow_unbound=True) is required."
+                        ),
                     },
                     "health_checks": {
                         "type": "array",
@@ -374,6 +434,31 @@ class LeanMCPInterface:
                         "type": "boolean",
                         "default": True,
                         "description": "Include detailed diagnostics",
+                    },
+                    "session_name": {
+                        "type": "string",
+                        "description": "Session name to resolve against when session_id is null.",
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "description": "Project context to monitor when session_id is null.",
+                    },
+                    "project_path": {
+                        "type": "string",
+                        "description": (
+                            "Absolute path to the caller's project; a project_name is "
+                            "derived from it when session_id is null. Relative paths "
+                            "are ignored."
+                        ),
+                    },
+                    "allow_unbound": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "Opt into the legacy '_unbound_' ambient-session fallback "
+                            "instead of raising when session_id is null and no other "
+                            "scope is supplied (deprecated)."
+                        ),
                     },
                 },
                 "required": ["session_id"],

--- a/src/session/server.py
+++ b/src/session/server.py
@@ -79,7 +79,7 @@ def safe_response(response_data: Any, operation: str) -> dict[str, Any]:
 
 
 @app.tool()
-def session_manage_lifecycle(
+async def session_manage_lifecycle(
     operation: str,
     mode: str = "local",
     project_name: str | None = None,
@@ -128,7 +128,7 @@ def session_manage_lifecycle(
             else:
                 parsed_metadata = {"metadata": str(metadata)}
 
-        result = session_engine.session_manage_lifecycle(
+        result = await session_engine.session_manage_lifecycle(
             operation=operation,
             mode=mode,
             project_name=project_name,
@@ -152,7 +152,7 @@ def session_manage_lifecycle(
 
 
 @app.tool()
-def session_track_execution(
+async def session_track_execution(
     agent_name: str,
     step_data: dict[str, Any],
     session_id: str | None = None,
@@ -197,7 +197,7 @@ def session_track_execution(
             f"{session_engine.claude_sessions_path}"
         )
 
-        result = session_engine.session_track_execution(
+        result = await session_engine.session_track_execution(
             session_id=session_id,
             agent_name=agent_name,
             step_data=step_data,
@@ -280,7 +280,7 @@ def session_coordinate_agents(
 
 
 @app.tool()
-def session_log_decision(
+async def session_log_decision(
     decision: str,
     session_id: str | None = None,
     context: dict[str, Any] | None = None,
@@ -304,7 +304,7 @@ def session_log_decision(
         DecisionResult with decision ID, impact analysis, linked decisions
     """
     try:
-        result = session_engine.session_log_decision(
+        result = await session_engine.session_log_decision(
             session_id=session_id,
             decision=decision,
             context=context,
@@ -371,7 +371,7 @@ def session_analyze_patterns(
 
 
 @app.tool()
-def session_monitor_health(
+async def session_monitor_health(
     session_id: str | None = None,
     health_checks: list[str] = None,
     auto_recover: bool = True,
@@ -408,7 +408,7 @@ def session_monitor_health(
         if health_checks is None:
             health_checks = ["continuity", "files", "state", "agents"]
 
-        result = session_engine.session_monitor_health(
+        result = await session_engine.session_monitor_health(
             session_id=session_id,
             health_checks=health_checks,
             auto_recover=auto_recover,

--- a/src/session/server.py
+++ b/src/session/server.py
@@ -83,8 +83,12 @@ def session_manage_lifecycle(
     operation: str,
     mode: str = "local",
     project_name: str | None = None,
+    project_path: str | None = None,
     metadata: Any | None = None,
     auto_recovery: bool = True,
+    session_id: str | None = None,
+    session_name: str | None = None,
+    allow_unbound: bool = False,
 ) -> dict[str, Any]:
     """
     Comprehensive session lifecycle management with intelligent tracking.
@@ -97,8 +101,14 @@ def session_manage_lifecycle(
         operation: Lifecycle operation ("create", "resume", "finalize", "validate")
         mode: Session mode ("local", "remote", "hybrid", "auto")
         project_name: Project context (optional)
+        project_path: Absolute path to the caller's project (optional)
         metadata: Additional session metadata as dict or JSON string (optional)
         auto_recovery: Enable automatic recovery (default: True)
+        session_id: Explicit session for resume/finalize/validate (optional)
+        session_name: Session name to resolve against (optional)
+        allow_unbound: For resume/finalize/validate, opt into the legacy
+            ambient-session fallback instead of raising when no scope is
+            supplied (deprecated)
 
     Returns:
         SessionResult with session ID, status, metadata, recovery options
@@ -122,8 +132,12 @@ def session_manage_lifecycle(
             operation=operation,
             mode=mode,
             project_name=project_name,
+            project_path=project_path,
             metadata=parsed_metadata,
             auto_recovery=auto_recovery,
+            session_id=session_id,
+            session_name=session_name,
+            allow_unbound=allow_unbound,
         )
         response = result
         return apply_token_limits(response, "session_manage_lifecycle")
@@ -144,6 +158,10 @@ def session_track_execution(
     session_id: str | None = None,
     track_patterns: bool = True,
     suggest_optimizations: bool = True,
+    session_name: str | None = None,
+    project_name: str | None = None,
+    project_path: str | None = None,
+    allow_unbound: bool = False,
 ) -> dict[str, Any]:
     """
     Advanced execution tracking with pattern detection and optimization.
@@ -158,6 +176,13 @@ def session_track_execution(
         session_id: Session ID or current session (optional)
         track_patterns: Enable pattern detection (default: True)
         suggest_optimizations: Generate optimization suggestions (default: True)
+        session_name: Session name to resolve against when session_id is omitted
+        project_name: Project context to bind to when session_id is omitted
+        project_path: Absolute path to derive project_name from when session_id
+            is omitted
+        allow_unbound: Opt into the legacy ambient-session fallback instead of
+            raising when session_id is omitted and no other scope is supplied
+            (deprecated)
 
     Returns:
         ExecutionTrackingResult with step ID, patterns detected, optimizations
@@ -178,6 +203,10 @@ def session_track_execution(
             step_data=step_data,
             track_patterns=track_patterns,
             suggest_optimizations=suggest_optimizations,
+            session_name=session_name,
+            project_name=project_name,
+            project_path=project_path,
+            allow_unbound=allow_unbound,
         )
 
         debug_logger.info(f"[EXEC-TRACK] Execution tracking result: {result}")
@@ -348,6 +377,10 @@ def session_monitor_health(
     auto_recover: bool = True,
     alert_thresholds: dict[str, float] | None = None,
     include_diagnostics: bool = True,
+    session_name: str | None = None,
+    project_name: str | None = None,
+    project_path: str | None = None,
+    allow_unbound: bool = False,
 ) -> dict[str, Any]:
     """
     Real-time session health monitoring with auto-recovery capabilities.
@@ -361,6 +394,12 @@ def session_monitor_health(
         auto_recover: Enable automatic recovery (default: True)
         alert_thresholds: Custom alert thresholds (optional)
         include_diagnostics: Include detailed diagnostics (default: True)
+        session_name: Session name to resolve against when session_id is None
+        project_name: Project context to monitor when session_id is None
+        project_path: Absolute path to derive project_name from when session_id is None
+        allow_unbound: Opt into the legacy ambient-session fallback instead of
+            raising when session_id is None and no other scope is supplied
+            (deprecated)
 
     Returns:
         SessionHealthResult with health score, issues, recovery actions, diagnostics
@@ -375,6 +414,10 @@ def session_monitor_health(
             auto_recover=auto_recover,
             alert_thresholds=alert_thresholds,
             include_diagnostics=include_diagnostics,
+            session_name=session_name,
+            project_name=project_name,
+            project_path=project_path,
+            allow_unbound=allow_unbound,
         )
         return safe_response(result, "session_manage_lifecycle")
     except Exception as e:

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -828,6 +828,10 @@ curl -X POST http://127.0.0.1:4002/tools/agent_query_learnings \\
                     "session_find_solution",
                     "session_update_solution_outcome",
                     "session_track_file_operation",
+                    # session_monitor_health now resolves session_name/project_name
+                    # scope through the database (issue #77), so it needs the same
+                    # pre-call DB sync as the other scope-resolving tools.
+                    "session_monitor_health",
                 }
 
                 try:

--- a/tests/engine/test_mcp_tool_dispatch.py
+++ b/tests/engine/test_mcp_tool_dispatch.py
@@ -230,9 +230,18 @@ class TestExecuteSessionManageLifecycle:
             assert inner.get("session_id") or inner.get("result", {}).get("session_id")
 
     async def test_execute_session_manage_lifecycle_validate(self, lean_interface):
-        """execute_tool session_manage_lifecycle validate runs without error."""
+        """execute_tool session_manage_lifecycle validate runs without error.
+
+        Issue #77: validate now requires an explicit scope (session_id here)
+        rather than falling back to ambient session_cache state.
+        """
         execute = _get_meta_tool(lean_interface, "execute_tool")
-        result = await execute("session_manage_lifecycle", {"operation": "validate"})
+        create_result = await execute("session_manage_lifecycle", {"operation": "create"})
+        session_id = _extract_session_id(create_result)
+        result = await execute(
+            "session_manage_lifecycle",
+            {"operation": "validate", "session_id": session_id},
+        )
         assert result["status"] == "success"
 
 
@@ -303,10 +312,28 @@ class TestExecuteSessionAnalyzePatterns:
 
 class TestExecuteSessionMonitorHealth:
     async def test_execute_session_monitor_health(self, lean_interface):
-        """session_monitor_health succeeds with session_id=None (current session)."""
+        """session_monitor_health succeeds with an explicit session_id.
+
+        Issue #77: session_id=None now requires session_name/project_name
+        (or allow_unbound=True) instead of silently resolving via ambient
+        session_cache state.
+        """
         execute = _get_meta_tool(lean_interface, "execute_tool")
-        result = await execute("session_monitor_health", {"session_id": None})
+        create_result = await execute("session_manage_lifecycle", {"operation": "create"})
+        session_id = _extract_session_id(create_result)
+        result = await execute("session_monitor_health", {"session_id": session_id})
         assert result["status"] == "success"
+
+    async def test_execute_session_monitor_health_null_session_id_requires_scope(
+        self, lean_interface
+    ):
+        """session_id=None with no session_name/project_name/allow_unbound
+        returns a status='error' envelope (SessionContextRequiredError),
+        not a silent fallback to ambient state."""
+        execute = _get_meta_tool(lean_interface, "execute_tool")
+        await execute("session_manage_lifecycle", {"operation": "create"})
+        result = await execute("session_monitor_health", {"session_id": None})
+        assert result["status"] == "error"
 
 
 class TestSessionOrchestrateWorkflowUnregistered:
@@ -613,10 +640,8 @@ class TestToolWrapperIntegrity:
         import inspect
 
         sync_tools = {
-            "session_track_execution",
             "session_coordinate_agents",
             "session_analyze_patterns",
-            "session_monitor_health",
             "session_orchestrate_workflow",
             "session_analyze_commands",
             "session_track_missing_functions",

--- a/tests/engine/test_session_lifecycle.py
+++ b/tests/engine/test_session_lifecycle.py
@@ -14,7 +14,7 @@ import inspect
 
 import pytest
 
-from core.session_engine import SessionIntelligenceEngine
+from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine
 from models.session_models import SessionHealthResult, SessionResult, SessionStatus
 
 
@@ -119,10 +119,11 @@ async def test_finalize_session(engine):
     create_result = await _create_session(engine)
     session_id = create_result.session_id
 
-    # Set the engine's current session pointer so finalize can find it
-    engine._current_session_id = session_id
-
-    finalize_result = await engine.session_manage_lifecycle(operation="finalize")
+    # Pass explicit scope (issue #77): finalize no longer resolves an
+    # unscoped call via ambient `_current_session_id`/session_cache state.
+    finalize_result = await engine.session_manage_lifecycle(
+        operation="finalize", session_id=session_id
+    )
 
     assert finalize_result.status == "success"
     assert finalize_result.operation == "finalize"
@@ -130,17 +131,26 @@ async def test_finalize_session(engine):
     assert finalize_result.session_data.status == SessionStatus.COMPLETED
 
 
-async def test_finalize_nonexistent_session(engine):
-    """Finalizing when no session was explicitly created still completes without
-    raising an exception — _finalize_session auto-creates a session via
-    _get_or_create_current_session_id, so the result is either 'success'
-    (auto-created and finalized) or 'error' (no session found). We verify no
-    exception is raised and that the result is a valid SessionResult."""
-    result = await engine.session_manage_lifecycle(operation="finalize")
+async def test_finalize_nonexistent_session_requires_scope(engine):
+    """Issue #77: finalizing with no session_id/session_name/project_name and
+    no allow_unbound now raises SessionContextRequiredError instead of
+    silently falling back to ambient `_get_or_create_current_session_id()`
+    state -- on a shared engine that state can belong to a different
+    project entirely."""
+    with pytest.raises(SessionContextRequiredError):
+        await engine.session_manage_lifecycle(operation="finalize")
+
+
+async def test_finalize_nonexistent_session_allow_unbound_still_completes(engine):
+    """The allow_unbound=True escape hatch preserves the pre-#77 ambient
+    behavior: it auto-creates/uses the ambient session and finalizes it
+    without raising."""
+    result = await engine.session_manage_lifecycle(
+        operation="finalize", allow_unbound=True
+    )
 
     assert isinstance(result, SessionResult)
     assert result.operation == "finalize"
-    # Valid terminal status — engine either auto-created+finalized or returned error
     assert result.status in {"success", "error"}
 
 
@@ -167,7 +177,7 @@ async def test_session_health_check(engine):
     create_result = await _create_session(engine)
     session_id = create_result.session_id
 
-    health = engine.session_monitor_health(session_id=session_id)
+    health = await engine.session_monitor_health(session_id=session_id)
 
     assert isinstance(health, SessionHealthResult)
     assert isinstance(health.health_score, float)
@@ -176,7 +186,7 @@ async def test_session_health_check(engine):
 
 async def test_session_health_no_session_returns_zero(engine):
     """Health monitoring with no active session returns health_score=0.0."""
-    health = engine.session_monitor_health(session_id="nonexistent-id")
+    health = await engine.session_monitor_health(session_id="nonexistent-id")
 
     assert health.health_score == 0.0
     assert len(health.issues) > 0
@@ -187,7 +197,7 @@ async def test_session_health_includes_diagnostics(engine):
     create_result = await _create_session(engine)
     session_id = create_result.session_id
 
-    health = engine.session_monitor_health(
+    health = await engine.session_monitor_health(
         session_id=session_id, include_diagnostics=True
     )
 
@@ -201,7 +211,7 @@ async def test_session_health_custom_checks(engine):
     create_result = await _create_session(engine)
     session_id = create_result.session_id
 
-    health = engine.session_monitor_health(
+    health = await engine.session_monitor_health(
         session_id=session_id,
         health_checks=["state"],  # only state check
     )

--- a/tests/regression/test_issue_25_finalize_persistence.py
+++ b/tests/regression/test_issue_25_finalize_persistence.py
@@ -91,8 +91,9 @@ async def test_finalize_persists_status_completed_to_db(engine):
     assert pre is not None, "Session row missing immediately after create"
     assert pre["status"] == "active"
 
-    engine._current_session_id = session_id
-    finalize_result = await engine.session_manage_lifecycle(operation="finalize")
+    finalize_result = await engine.session_manage_lifecycle(
+        operation="finalize", session_id=session_id
+    )
     assert finalize_result.status == "success"
 
     # Post-finalize: DB row must reflect completed status. Pre-fix this
@@ -122,8 +123,7 @@ async def test_finalize_clears_active_session_for_find_recent(engine):
     assert active_before is not None
     assert active_before["id"] == session_id
 
-    engine._current_session_id = session_id
-    await engine.session_manage_lifecycle(operation="finalize")
+    await engine.session_manage_lifecycle(operation="finalize", session_id=session_id)
 
     # After finalize: no active session matches the project anymore.
     active_after = await engine.database.find_recent_session_by_project(
@@ -150,8 +150,7 @@ async def test_finalize_removes_session_from_cache(engine):
     session_id = create_result.session_id
     assert session_id in engine.session_cache
 
-    engine._current_session_id = session_id
-    await engine.session_manage_lifecycle(operation="finalize")
+    await engine.session_manage_lifecycle(operation="finalize", session_id=session_id)
 
     assert session_id not in engine.session_cache, (
         "Finalized session is still in session_cache. This violates "
@@ -179,8 +178,9 @@ async def test_disk_reload_skips_completed_session(engine_with_fs):
         operation="create", mode="local", project_name="issue-25-disk"
     )
     completed_id = create_result.session_id
-    engine_with_fs._current_session_id = completed_id
-    await engine_with_fs.session_manage_lifecycle(operation="finalize")
+    await engine_with_fs.session_manage_lifecycle(
+        operation="finalize", session_id=completed_id
+    )
 
     # Sanity: metadata file says completed.
     session_dir = engine_with_fs.claude_sessions_path / completed_id

--- a/tests/regression/test_issue_33_hook_session_binding.py
+++ b/tests/regression/test_issue_33_hook_session_binding.py
@@ -58,7 +58,7 @@ async def test_hook_session_id_auto_binds_on_first_track_execution(engine):
     """A native Claude Code session UUID that was never created via
     `session_manage_lifecycle create` must auto-bind on first use instead
     of failing with status='error-session-not-found'."""
-    result = engine.session_track_execution(
+    result = await engine.session_track_execution(
         session_id=NATIVE_SESSION_ID,
         agent_name="focused-code-modifier",
         step_data={"operation": "start", "description": "SubagentStart hook"},
@@ -86,7 +86,7 @@ async def test_hook_session_id_reused_on_second_track_execution(engine):
     """Two calls with the same native session id (simulating SubagentStart
     then SubagentStop) must reuse the exact same cached Session rather than
     creating a duplicate or erroring on the second call."""
-    first_result = engine.session_track_execution(
+    first_result = await engine.session_track_execution(
         session_id=NATIVE_SESSION_ID,
         agent_name="focused-code-modifier",
         step_data={"operation": "start", "description": "SubagentStart hook"},
@@ -95,7 +95,7 @@ async def test_hook_session_id_reused_on_second_track_execution(engine):
     assert NATIVE_SESSION_ID in engine.session_cache
     first_session = engine.session_cache[NATIVE_SESSION_ID]
 
-    second_result = engine.session_track_execution(
+    second_result = await engine.session_track_execution(
         session_id=NATIVE_SESSION_ID,
         agent_name="focused-code-modifier",
         step_data={"operation": "stop", "description": "SubagentStop hook"},

--- a/tests/regression/test_issue_39_agent_execution_status_transition.py
+++ b/tests/regression/test_issue_39_agent_execution_status_transition.py
@@ -59,10 +59,11 @@ async def test_agent_stop_success_transitions_to_success_status(engine):
     """A SubagentStart-like call followed by an agent_stop call with
     success=True must transition the AgentExecution out of RUNNING into
     SUCCESS, not leave it stuck at RUNNING."""
-    start_result = engine.session_track_execution(
+    start_result = await engine.session_track_execution(
         session_id=None,
         agent_name=AGENT_NAME,
         step_data={"operation": "start", "description": "SubagentStart hook"},
+        allow_unbound=True,
     )
     assert start_result.status == "success"
     session_id = start_result.session_id
@@ -73,7 +74,7 @@ async def test_agent_stop_success_transitions_to_success_status(engine):
     )
     assert agent_execution.status == ExecutionStatus.RUNNING
 
-    stop_result = engine.session_track_execution(
+    stop_result = await engine.session_track_execution(
         session_id=session_id,
         agent_name=AGENT_NAME,
         step_data={
@@ -103,14 +104,15 @@ async def test_agent_stop_success_transitions_to_success_status(engine):
 async def test_agent_stop_failure_transitions_to_error_status(engine):
     """An agent_stop call with success=False must transition the
     AgentExecution into ERROR, not leave it stuck at RUNNING."""
-    start_result = engine.session_track_execution(
+    start_result = await engine.session_track_execution(
         session_id=None,
         agent_name=AGENT_NAME,
         step_data={"operation": "start", "description": "SubagentStart hook"},
+        allow_unbound=True,
     )
     session_id = start_result.session_id
 
-    stop_result = engine.session_track_execution(
+    stop_result = await engine.session_track_execution(
         session_id=session_id,
         agent_name=AGENT_NAME,
         step_data={
@@ -140,7 +142,7 @@ async def test_agent_stop_failure_transitions_to_error_status(engine):
 async def test_non_agent_stop_phase_keeps_running_status(engine):
     """Phases other than agent_stop (e.g. agent_start) must continue to
     create/append RUNNING steps, unaffected by the agent_stop fix."""
-    start_result = engine.session_track_execution(
+    start_result = await engine.session_track_execution(
         session_id=None,
         agent_name=AGENT_NAME,
         step_data={
@@ -148,6 +150,7 @@ async def test_non_agent_stop_phase_keeps_running_status(engine):
             "operation": "start",
             "description": "SubagentStart hook",
         },
+        allow_unbound=True,
     )
     assert start_result.status == "success"
     session_id = start_result.session_id

--- a/tests/regression/test_issue_41_agent_type_resolution.py
+++ b/tests/regression/test_issue_41_agent_type_resolution.py
@@ -70,7 +70,7 @@ async def test_agent_stop_empty_agent_type_backfilled_from_cache(engine):
     Stop-phase call for the SAME agent_name reporting agent_type="" (the
     harness quirk), must not persist the empty string. The cached real
     value from the Start call must backfill the existing AgentExecution."""
-    start_result = engine.session_track_execution(
+    start_result = await engine.session_track_execution(
         session_id=None,
         agent_name=AGENT_NAME,
         step_data={
@@ -79,6 +79,7 @@ async def test_agent_stop_empty_agent_type_backfilled_from_cache(engine):
             "operation": "start",
             "description": "SubagentStart hook",
         },
+        allow_unbound=True,
     )
     assert start_result.status == "success"
     session_id = start_result.session_id
@@ -89,7 +90,7 @@ async def test_agent_stop_empty_agent_type_backfilled_from_cache(engine):
     )
     assert agent_execution.agent_type == "focused-code-modifier"
 
-    stop_result = engine.session_track_execution(
+    stop_result = await engine.session_track_execution(
         session_id=session_id,
         agent_name=AGENT_NAME,
         step_data={
@@ -116,7 +117,7 @@ async def test_no_prior_cache_falls_back_to_unknown(engine):
     step_data reports an empty/missing agent_type, the result must still
     fall back to "unknown" - no silent substitution of a wrong value,
     and no regression of existing pre-#41 behavior."""
-    result = engine.session_track_execution(
+    result = await engine.session_track_execution(
         session_id=None,
         agent_name="brand-new-agent-hexid",
         step_data={
@@ -124,6 +125,7 @@ async def test_no_prior_cache_falls_back_to_unknown(engine):
             "operation": "start",
             "description": "SubagentStart hook",
         },
+        allow_unbound=True,
     )
     assert result.status == "success"
     session_id = result.session_id
@@ -143,7 +145,7 @@ async def test_later_real_agent_type_updates_stale_cached_value(engine):
     invocation) with a genuinely different real agent_type on its own
     Start-equivalent call, the cache must update to the newer real
     value - last-real-value-wins, not stuck on the first-seen value."""
-    first_start = engine.session_track_execution(
+    first_start = await engine.session_track_execution(
         session_id=None,
         agent_name=AGENT_NAME,
         step_data={
@@ -152,11 +154,12 @@ async def test_later_real_agent_type_updates_stale_cached_value(engine):
             "operation": "start",
             "description": "first invocation",
         },
+        allow_unbound=True,
     )
     session_id = first_start.session_id
     session = engine.session_cache[session_id]
 
-    first_stop = engine.session_track_execution(
+    first_stop = await engine.session_track_execution(
         session_id=session_id,
         agent_name=AGENT_NAME,
         step_data={"phase": "agent_stop", "agent_type": "", "success": True},
@@ -166,7 +169,7 @@ async def test_later_real_agent_type_updates_stale_cached_value(engine):
     # A later, unrelated invocation of the same agent_name (e.g. the
     # subagent was re-dispatched under a different role) reports a
     # genuinely different real agent_type.
-    second_start = engine.session_track_execution(
+    second_start = await engine.session_track_execution(
         session_id=session_id,
         agent_name=AGENT_NAME,
         step_data={
@@ -186,7 +189,7 @@ async def test_later_real_agent_type_updates_stale_cached_value(engine):
     )
     assert second_execution.agent_type == "focused-quality-resolver"
 
-    second_stop = engine.session_track_execution(
+    second_stop = await engine.session_track_execution(
         session_id=session_id,
         agent_name=AGENT_NAME,
         step_data={"phase": "agent_stop", "agent_type": "", "success": True},

--- a/tests/regression/test_issue_77_finalize_scope_binding.py
+++ b/tests/regression/test_issue_77_finalize_scope_binding.py
@@ -1,0 +1,234 @@
+"""
+Regression tests for issue #77: session_manage_lifecycle's finalize/resume/
+validate operations dropped session_id/session_name/project_name/project_path
+at the dispatch layer, so they always fell back to ambient in-process state
+(`_get_or_create_current_session_id()` or `list(session_cache.keys())[-1]`)
+even when a caller explicitly supplied a scope. Because the HTTP transport
+builds a SINGLE SessionIntelligenceEngine shared across every project
+(http_server.py lifespan()), that ambient state belongs to whichever project
+most recently created/touched a session in the process -- not the caller.
+This is how a caller scoped to "session-intelligence" finalized a
+"hummingbot" session.
+
+Fix: `_manage_lifecycle_impl` now forwards session_id/session_name/
+project_name/project_path/allow_unbound into the resume/finalize/validate
+branches, and each of `_resume_session`, `_finalize_session`,
+`_validate_session` now requires at least one of session_id/session_name/
+project_name (or an absolute project_path a project_name can be derived
+from), raising SessionContextRequiredError otherwise, unless
+allow_unbound=True opts into the legacy fallback.
+
+Every pre-#72 resolver test built a FRESH engine per test, which is exactly
+why this bug class (#72, #74, and now #77) kept shipping. These tests reuse
+a SINGLE engine across TWO projects, with the *other* project's session
+created SECOND so it is the last key in session_cache -- the value the old
+buggy code would have picked.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core.session_engine import SessionContextRequiredError, SessionIntelligenceEngine
+from models.session_models import SessionStatus
+from persistence.sqlite import SQLiteBackend
+
+
+@pytest.mark.regression
+class TestUnboundLifecycleOpsAreRejected:
+    """finalize/resume/validate must reject an unscoped call instead of
+    silently falling back to ambient state."""
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path), use_filesystem=False)
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def test_finalize_without_scope_raises(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        with pytest.raises(SessionContextRequiredError) as exc_info:
+            await engine.session_manage_lifecycle(operation="finalize")
+        assert "finalize" in str(exc_info.value)
+
+    async def test_resume_without_scope_raises(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        with pytest.raises(SessionContextRequiredError) as exc_info:
+            await engine.session_manage_lifecycle(operation="resume")
+        assert "resume" in str(exc_info.value)
+
+    async def test_validate_without_scope_raises(self, engine):
+        await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+
+        with pytest.raises(SessionContextRequiredError) as exc_info:
+            await engine.session_manage_lifecycle(operation="validate")
+        assert "validate" in str(exc_info.value)
+
+    async def test_finalize_allow_unbound_escape_hatch_still_works(self, engine):
+        create_result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+        engine._current_session_id = create_result.session_id
+
+        result = await engine.session_manage_lifecycle(
+            operation="finalize", allow_unbound=True
+        )
+        assert result.status == "success"
+
+    async def test_resume_allow_unbound_escape_hatch_still_works(self, engine):
+        create_result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+        engine._current_session_id = create_result.session_id
+
+        result = await engine.session_manage_lifecycle(
+            operation="resume", allow_unbound=True
+        )
+        assert result.status == "success"
+
+    async def test_validate_allow_unbound_escape_hatch_still_works(self, engine):
+        create_result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-a"
+        )
+        engine._current_session_id = create_result.session_id
+
+        result = await engine.session_manage_lifecycle(
+            operation="validate", allow_unbound=True
+        )
+        assert result.status in {"success", "warning"}
+
+
+@pytest.mark.regression
+class TestSharedEngineDoesNotBleedAcrossProjects:
+    """A single engine shared by two projects, with the OTHER project's
+    session created SECOND so it sits last in session_cache -- the value the
+    pre-#77 ambient fallback would have picked."""
+
+    @pytest.fixture
+    async def engine(self, tmp_path):
+        eng = SessionIntelligenceEngine(repository_path=str(tmp_path), use_filesystem=False)
+        eng.database = SQLiteBackend(str(tmp_path / "test.db"))
+        await eng.database.initialize()
+        yield eng
+        await eng.database.close()
+
+    async def _create_two_projects(self, engine, tmp_path: Path):
+        proj_a_dir = tmp_path / "proj-a"
+        proj_a_dir.mkdir()
+        proj_b_dir = tmp_path / "proj-b"
+        proj_b_dir.mkdir()
+
+        proj_a_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-a",
+            project_path=str(proj_a_dir),
+        )
+        # proj-b is created SECOND: it is the last key in session_cache when
+        # the caller's finalize/resume/validate call below is made.
+        proj_b_create = await engine.session_manage_lifecycle(
+            operation="create",
+            mode="local",
+            project_name="proj-b",
+            project_path=str(proj_b_dir),
+        )
+
+        cache_keys = list(engine.session_cache.keys())
+        assert cache_keys[-1] == proj_b_create.session_id, (
+            "Precondition failed: proj-b's session is not the last key in "
+            "session_cache, so this test would not actually exercise the "
+            "#77 ambient-fallback bug even if the fix were reverted."
+        )
+        return proj_a_create, proj_b_create
+
+    async def test_finalize_binds_to_caller_project_not_last_cache_key(
+        self, engine, tmp_path
+    ):
+        proj_a_create, proj_b_create = await self._create_two_projects(engine, tmp_path)
+
+        result = await engine.session_manage_lifecycle(
+            operation="finalize", project_name="proj-a"
+        )
+
+        assert result.status == "success"
+        assert result.session_id == proj_a_create.session_id, (
+            "Issue #77: finalize resolved to the wrong session. It must "
+            "bind to proj-a's session (the caller's project_name), not fall "
+            "back to whichever project last created a session."
+        )
+        assert result.session_id != proj_b_create.session_id
+
+        # proj-a's session is finalized and dropped from the cache...
+        assert proj_a_create.session_id not in engine.session_cache
+        # ...while proj-b's untouched session remains active in the cache.
+        assert proj_b_create.session_id in engine.session_cache
+        assert (
+            engine.session_cache[proj_b_create.session_id].status
+            == SessionStatus.ACTIVE
+        )
+
+    async def test_finalize_binds_by_absolute_project_path(self, engine, tmp_path):
+        proj_a_create, proj_b_create = await self._create_two_projects(engine, tmp_path)
+
+        result = await engine.session_manage_lifecycle(
+            operation="finalize", project_path=str(tmp_path / "proj-a")
+        )
+
+        assert result.status == "success"
+        assert result.session_id == proj_a_create.session_id
+        assert result.session_id != proj_b_create.session_id
+
+    async def test_finalize_explicit_session_id_wins(self, engine, tmp_path):
+        proj_a_create, proj_b_create = await self._create_two_projects(engine, tmp_path)
+
+        result = await engine.session_manage_lifecycle(
+            operation="finalize", session_id=proj_a_create.session_id
+        )
+
+        assert result.status == "success"
+        assert result.session_id == proj_a_create.session_id
+        assert result.session_id != proj_b_create.session_id
+
+    async def test_resume_binds_to_caller_project_not_last_cache_key(
+        self, engine, tmp_path
+    ):
+        proj_a_create, proj_b_create = await self._create_two_projects(engine, tmp_path)
+
+        result = await engine.session_manage_lifecycle(
+            operation="resume", project_name="proj-a"
+        )
+
+        assert result.status == "success"
+        assert result.session_id == proj_a_create.session_id, (
+            "Issue #77: resume resolved to the wrong session. It must bind "
+            "to proj-a's session, not fall back to the last-created session."
+        )
+        assert result.session_id != proj_b_create.session_id
+        assert engine._current_session_id == proj_a_create.session_id
+
+    async def test_validate_binds_to_caller_project_not_last_cache_key(
+        self, engine, tmp_path
+    ):
+        proj_a_create, proj_b_create = await self._create_two_projects(engine, tmp_path)
+
+        result = await engine.session_manage_lifecycle(
+            operation="validate", project_name="proj-a"
+        )
+
+        assert result.status in {"success", "warning"}
+        assert result.session_id == proj_a_create.session_id, (
+            "Issue #77: validate resolved to the wrong session. It must "
+            "bind to proj-a's session, not fall back to the last-created "
+            "session."
+        )
+        assert result.session_id != proj_b_create.session_id

--- a/tests/unit/test_session_project_binding_regression.py
+++ b/tests/unit/test_session_project_binding_regression.py
@@ -63,7 +63,7 @@ def fake_remote_git(monkeypatch: pytest.MonkeyPatch):
 # ---------------------------------------------------------------------------
 
 
-def test_hook_bound_execution_tracking_does_not_produce_unbound_session(
+async def test_hook_bound_execution_tracking_does_not_produce_unbound_session(
     session_engine, tmp_path: Path, fake_remote_git
 ) -> None:
     """Drives the real regressed path: session_track_execution() called with
@@ -74,7 +74,7 @@ def test_hook_bound_execution_tracking_does_not_produce_unbound_session(
     working_dir = tmp_path / "hook-workdir"
     working_dir.mkdir()
 
-    result = session_engine.session_track_execution(
+    result = await session_engine.session_track_execution(
         session_id="claude-native-session-abc123",
         agent_name="test-agent",
         step_data={"working_directory": str(working_dir)},
@@ -105,7 +105,7 @@ def test_hook_bound_execution_tracking_does_not_produce_unbound_session(
 # ---------------------------------------------------------------------------
 
 
-def test_auto_current_session_id_still_uses_unbound_sentinel(
+async def test_auto_current_session_id_still_uses_unbound_sentinel(
     session_engine, tmp_path: Path, fake_remote_git, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """No session_id supplied and no existing current session -> engine
@@ -114,15 +114,21 @@ def test_auto_current_session_id_still_uses_unbound_sentinel(
     if this path were wired to use it, it must still stamp '_unbound_':
     this path only has the server process's own cwd, not a caller-supplied
     working directory, and allow_unbound=True callers rely on this sentinel
-    being stable."""
+    being stable.
+
+    allow_unbound=True is passed explicitly (issue #77): session_id=None
+    with no session_name/project_name now requires it, otherwise
+    SessionContextRequiredError is raised instead of silently reaching this
+    ambient fallback."""
     working_dir = tmp_path / "auto-workdir"
     working_dir.mkdir()
     monkeypatch.chdir(working_dir)
 
-    result = session_engine.session_track_execution(
+    result = await session_engine.session_track_execution(
         session_id=None,
         agent_name="test-agent",
         step_data={},
+        allow_unbound=True,
     )
 
     assert result.status == "success", f"unexpected status: {result.status}"


### PR DESCRIPTION
## Root cause

`_manage_lifecycle_impl` (`src/core/session_engine.py`) forwarded `session_id`/`session_name`/`project_name`/`project_path`/`allow_unbound` into the **create** branch only. The **resume/finalize/validate** branches called `_resume_session()` / `_finalize_session()` / `_validate_session()` with **ZERO arguments**, even though `session_manage_lifecycle` already accepted `project_name`/`project_path` from the caller (e.g. the Stop hook). Scope was declared in the MCP schema, accepted from the caller, and silently dropped at dispatch -- so those three operations always fell back to ambient in-process state (`_get_or_create_current_session_id()` or `list(session_cache.keys())[-1]`). Because the HTTP transport builds a **single** `SessionIntelligenceEngine` shared across every project, that ambient state belongs to whichever project most recently touched a session in the process -- not the caller. This is how a caller scoped to `session-intelligence` finalized a `hummingbot` session.

## Sites fixed (6, not just finalize)

1. `_manage_lifecycle_impl` -- now forwards session_id/session_name/project_name/project_path/allow_unbound into resume/finalize/validate (the central fix; `create` is unaffected).
2. `_resume_session` -- replaced `list(session_cache.keys())[-1]` with the #74 guard idiom + `_resolve_session_context(create_if_missing=False)`.
3. `_validate_session` -- same idiom.
4. `_track_execution_sync` (`session_track_execution`) -- replaced the ambient `_get_or_create_current_session_id()` fallback with the guard idiom; made **async** to reach the async resolver (matches `session_track_file_operation`'s existing pattern).
5. `_monitor_health_sync` (`session_monitor_health`) -- same treatment, also made async.
6. `_create_notebook_impl` -- latent (both public wrappers already resolve `session_id` first); closed defensively by raising instead of falling back to the ambient helper.

## Breaking change (by design)

`resume`/`finalize`/`validate`/`session_track_execution`/`session_monitor_health` now require at least one of `session_id`/`session_name`/`project_name` (or an absolute `project_path` a `project_name` can be derived from) when `session_id` is omitted/None. `allow_unbound=True` opts into the legacy ambient fallback.

## Schema changes

- **`src/lean_mcp_interface.py`**: added `session_id`/`session_name`/`allow_unbound` to `session_manage_lifecycle`; added `session_name`/`project_name`/`project_path`/`allow_unbound` to `session_track_execution` and `session_monitor_health`; both upgraded from `_wrap_tool` to `_wrap_async_tool` (now async engine methods).
- **`src/session/server.py`**: same parameters added to the corresponding tool registrations (read-only verified -- this transport has zero test coverage and already called these async engine methods without `await` before this change; left otherwise untouched).
- **`src/transport/http_server.py`**: `session_monitor_health` added to `session_modifying_tools` since it now does DB-backed scope resolution.

## Tests

- New `tests/regression/test_issue_77_finalize_scope_binding.py` -- unscoped-raises, allow_unbound escape hatch, and shared-engine (two projects, second-created is last cache key) binding for finalize/resume/validate, following the #74 pattern (single engine, real project dirs on disk).
- Updated tests broken by the async conversion + new guard: `test_issue_41_agent_type_resolution.py`, `test_issue_39_agent_execution_status_transition.py`, `test_issue_33_hook_session_binding.py`, `test_session_project_binding_regression.py` (added `await` + `allow_unbound=True` where the ambient fallback was the point of the test), `test_session_lifecycle.py` (explicit scope on finalize; rewrote `test_finalize_nonexistent_session`, whose whole purpose was asserting the old ambient behavior), `test_issue_25_finalize_persistence.py` (explicit `session_id` on finalize), `test_mcp_tool_dispatch.py` (sync/async tool-wrapper integrity set updated; two tests that called validate/monitor_health unscoped now pass explicit scope).

## Blast radius

`~/.claude/hooks/session_intelligence_post_tool.py:284-292` tracks bash successes with **no scope** (session_id/session_name/project_name all absent) -- it will start raising `SessionContextRequiredError` once this ships and must be updated (pass `project_name`, or `allow_unbound=True`) **before** the session-intelligence service is restarted.

## Verification

```
555 passed, 74 skipped in 50.58s
```
ruff lint: All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)