### PR TITLE
fix(session): reap abandoned sessions instead of resurrecting them (closes #69)

### DIFF
--- a/scripts/migrations/reap_stale_active_sessions.py
+++ b/scripts/migrations/reap_stale_active_sessions.py
@@ -1,0 +1,225 @@
+"""One-time reap of pre-existing stale 'active' sessions (issue #69).
+
+Background:
+    Nothing ever transitioned an abandoned session out of status='active'
+    before this fix -- sessions only became 'completed' via an explicit
+    finalize call. As of 2026-08-15, 630 sessions were status='active', 615
+    of them more than a day old (dating back to Dec 2025), collectively
+    owning 10,708 agent_executions (73% of that table).
+
+    The application-level fix (reap_abandoned_sessions(), called once at
+    HTTP transport startup, plus the read-path staleness guard in
+    get_active_session_for_project / find_recent_session_by_project) only
+    takes effect going forward and on process restart. This script is a
+    ONE-TIME cleanup for rows that were already stale before the fix
+    shipped. It intentionally duplicates the app's UPDATE rather than
+    calling reap_abandoned_sessions() directly, so it can run standalone
+    (dry-run) without importing the full server stack.
+
+Known limitation (deferred, see issue #69 and persistence/base.py
+get_session_max_age_hours()):
+    started_at is the only staleness signal available today. A genuinely
+    long-lived session that has stayed open past --older-than-hours will be
+    incorrectly flagged as abandoned. A last_seen_at heartbeat column would
+    fix this but requires a schema migration; that is DEFERRED.
+
+Safety:
+    - Default mode is DRY-RUN (report only, no writes).
+    - --apply is required to write. There is no additional confirmation flag
+      by design (this script is invoked deliberately, unlike the interactive
+      backfill scripts) -- but per project policy this script is checked in
+      and is NOT to be executed against the production database as part of
+      landing this fix. Running it (even in dry-run) against production is a
+      separate, explicit operational decision.
+    - Rows are flipped to 'abandoned', NEVER 'completed' -- the distinction
+      is the point: these sessions were never explicitly finalized.
+
+Usage (report only, safe to run anytime):
+    PYTHONPATH=src python scripts/migrations/reap_stale_active_sessions.py
+
+Usage (apply, default 24h threshold):
+    PYTHONPATH=src python scripts/migrations/reap_stale_active_sessions.py --apply
+
+Usage (custom threshold):
+    PYTHONPATH=src python scripts/migrations/reap_stale_active_sessions.py \
+        --older-than-hours 72
+
+Environment variables:
+    SESSION_DB_DSN  PostgreSQL DSN (same variable the application reads via
+                     persistence.config.DatabaseConfig; falls back to
+                     DEFAULT_POSTGRES_DSN like the app does if unset)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import urllib.parse
+from datetime import UTC, datetime, timedelta
+
+from persistence.base import DEFAULT_SESSION_MAX_AGE_HOURS
+from persistence.config import DatabaseConfig
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def get_db_name(dsn: str) -> str:
+    """Extract the database name from a PostgreSQL DSN for operator confirmation."""
+    parsed = urllib.parse.urlparse(dsn)
+    return parsed.path.lstrip("/") or "(unspecified)"
+
+
+def print_month_summary(month_counts: dict[str, int], total: int, label: str) -> None:
+    """Print a month -> row_count table, matching the issue's reporting format."""
+    print()
+    print(f"{label}")
+    print(f"{'month':<10} {'row_count':>10}")
+    print("-" * 21)
+    for month in sorted(month_counts):
+        print(f"{month:<10} {month_counts[month]:>10}")
+    print("-" * 21)
+    print(f"{'total':<10} {total:>10}")
+    print()
+
+
+async def reap(dsn: str, apply_changes: bool, older_than_hours: int) -> None:
+    """Report (dry-run) or apply the reap of stale 'active' sessions."""
+    try:
+        import asyncpg
+    except ImportError:
+        logger.error("asyncpg is required for PostgreSQL. Install with: pip install asyncpg")
+        sys.exit(1)
+
+    db_name = get_db_name(dsn)
+    logger.info(f"Target database: {db_name}")
+    logger.info(f"Staleness threshold: {older_than_hours}h")
+
+    cutoff = datetime.now(UTC) - timedelta(hours=older_than_hours)
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        total_active = await conn.fetchval(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'active'"
+        )
+        logger.info(f"Total rows currently status='active': {total_active}")
+
+        before_rows = await conn.fetch(
+            """
+            SELECT to_char(started_at, 'YYYY-MM') AS month, COUNT(*) AS row_count
+            FROM sessions
+            WHERE status = 'active' AND started_at < $1
+            GROUP BY month
+            ORDER BY month
+            """,
+            cutoff,
+        )
+        before_counts = {row["month"]: row["row_count"] for row in before_rows}
+        would_change = sum(before_counts.values())
+
+        print_month_summary(
+            before_counts,
+            would_change,
+            "Stale 'active' sessions BY MONTH (started_at < cutoff):",
+        )
+        logger.info(
+            f"{would_change} of {total_active} active rows are older than "
+            f"the {older_than_hours}h threshold and would move to 'abandoned'."
+        )
+
+        if not apply_changes:
+            logger.info(
+                "DRY RUN complete — no changes written. Re-run with --apply to write."
+            )
+            return
+
+        result = await conn.execute(
+            """
+            UPDATE sessions
+            SET status = 'abandoned'
+            WHERE status = 'active' AND started_at < $1
+            """,
+            cutoff,
+        )
+        try:
+            updated = int(result.split()[-1])
+        except (IndexError, ValueError):
+            updated = 0
+
+        remaining_active = await conn.fetchval(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'active'"
+        )
+        total_abandoned = await conn.fetchval(
+            "SELECT COUNT(*) FROM sessions WHERE status = 'abandoned'"
+        )
+        logger.info(f"APPLY complete: {updated} rows moved to 'abandoned'.")
+        logger.info(f"Remaining status='active' rows: {remaining_active}")
+        logger.info(f"Total status='abandoned' rows: {total_abandoned}")
+    finally:
+        await conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reap pre-existing stale 'active' sessions to 'abandoned' "
+            "(one-time cleanup for issue #69). Dry-run by default."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help=(
+            "PostgreSQL DSN. Defaults to the same config the app uses "
+            "(SESSION_DB_DSN env var, or DEFAULT_POSTGRES_DSN)."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report only, never write (default mode)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the UPDATE. Not run as part of shipping this fix; a separate, "
+        "explicit operational decision.",
+    )
+    parser.add_argument(
+        "--older-than-hours",
+        type=int,
+        default=DEFAULT_SESSION_MAX_AGE_HOURS,
+        help=f"Staleness threshold in hours (default: {DEFAULT_SESSION_MAX_AGE_HOURS})",
+    )
+    args = parser.parse_args()
+
+    if not args.dsn:
+        args.dsn = (
+            DatabaseConfig.load().postgresql_dsn
+            or os.environ.get("SESSION_DB_DSN")
+        )
+    if not args.dsn:
+        from persistence.base import DEFAULT_POSTGRES_DSN
+
+        args.dsn = DEFAULT_POSTGRES_DSN
+
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(
+        reap(
+            args.dsn,
+            apply_changes=args.apply,
+            older_than_hours=args.older_than_hours,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/session_models.py
+++ b/src/models/session_models.py
@@ -21,6 +21,7 @@ class SessionStatus(StrEnum):
     COMPLETED = "completed"
     FAILED = "failed"
     RECOVERED = "recovered"
+    ABANDONED = "abandoned"  # Issue #69: reaped for staleness, never explicitly finalized
 
 
 class ExecutionStatus(StrEnum):

--- a/src/persistence/base.py
+++ b/src/persistence/base.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -22,6 +23,32 @@ DEFAULT_DATA_DIR = Path.home() / ".claude" / "session-intelligence"
 DEFAULT_POSTGRES_DSN = "postgresql://localhost/session_intelligence"
 # SQLite path for testing (SQLite is test-only, not for production)
 DEFAULT_SQLITE_PATH = DEFAULT_DATA_DIR / "sessions.db"
+
+# Issue #69: staleness threshold (hours) for 'active' sessions. A session
+# that never received an explicit finalize call stays 'active' forever
+# unless something reaps it. This single constant backs both the read guard
+# (get_active_session_for_project / find_recent_session_by_project) and the
+# startup sweep (reap_abandoned_sessions) in both backends, so they can never
+# drift apart. Overridable via SESSION_INTELLIGENCE_SESSION_MAX_AGE_HOURS.
+DEFAULT_SESSION_MAX_AGE_HOURS = 24
+
+
+def get_session_max_age_hours() -> int:
+    """Return the staleness threshold (hours) for 'active' sessions.
+
+    NOTE (deferred, issue #69): `started_at` is currently the only
+    staleness signal available. A genuinely long-lived session that stays
+    open past this threshold is indistinguishable from an abandoned one and
+    will be incorrectly excluded/reaped. A `last_seen_at` heartbeat column
+    would fix this but requires a schema migration.
+    """
+    raw = os.environ.get("SESSION_INTELLIGENCE_SESSION_MAX_AGE_HOURS")
+    if raw is None:
+        return DEFAULT_SESSION_MAX_AGE_HOURS
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_SESSION_MAX_AGE_HOURS
 
 
 def get_default_data_dir() -> Path:
@@ -154,6 +181,15 @@ class DatabaseBackend(Protocol):
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session by ID. Returns True if deleted."""
+        ...
+
+    async def reap_abandoned_sessions(self, older_than_hours: int | None = None) -> int:
+        """Flip stale 'active' sessions to 'abandoned'. Returns rows affected.
+
+        Distinct from 'completed': an abandoned session never received an
+        explicit finalize call, so the status stays honest about that.
+        Defaults to get_session_max_age_hours() when older_than_hours is None.
+        """
         ...
 
     # Decision operations

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 try:
@@ -25,7 +26,13 @@ try:
 except ImportError:
     asyncpg = None  # type: ignore
 
-from .base import DEFAULT_POSTGRES_DSN, BaseDatabaseBackend, db_retry, sanitize_dsn
+from .base import (
+    DEFAULT_POSTGRES_DSN,
+    BaseDatabaseBackend,
+    db_retry,
+    get_session_max_age_hours,
+    sanitize_dsn,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -558,22 +565,58 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
     @db_retry
     async def get_active_session_for_project(self, project_path: str) -> dict[str, Any] | None:
-        """Get the most recent active session for a project path."""
+        """Get the most recent active session for a project path.
+
+        Issue #69: excludes sessions older than get_session_max_age_hours() so a
+        session abandoned without an explicit finalize is not resurrected as the
+        current session for new work. See get_session_max_age_hours() for the
+        started_at-only staleness caveat.
+        """
         pool = self._ensure_connected()
+        cutoff = datetime.now(UTC) - timedelta(hours=get_session_max_age_hours())
 
         async with pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
                 SELECT * FROM sessions
-                WHERE project_path = $1 AND status = 'active'
+                WHERE project_path = $1 AND status = 'active' AND started_at >= $2
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
                 project_path,
+                cutoff,
             )
             if row:
                 return self._normalize_session_data(self._from_record(row))
             return None
+
+    @db_retry
+    async def reap_abandoned_sessions(self, older_than_hours: int | None = None) -> int:
+        """Flip stale 'active' sessions to 'abandoned'. Returns rows affected.
+
+        Issue #69: run once at server startup so no process resurrects a
+        months-old 'active' session via get_active_session_for_project /
+        find_recent_session_by_project. Uses 'abandoned', not 'completed', so
+        the data stays honest about never having been finalized. See
+        get_session_max_age_hours() for the started_at-only staleness caveat.
+        """
+        pool = self._ensure_connected()
+        hours = older_than_hours if older_than_hours is not None else get_session_max_age_hours()
+        cutoff = datetime.now(UTC) - timedelta(hours=hours)
+
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                """
+                UPDATE sessions
+                SET status = 'abandoned'
+                WHERE status = 'active' AND started_at < $1
+                """,
+                cutoff,
+            )
+            try:
+                return int(result.split()[-1])
+            except (IndexError, ValueError):
+                return 0
 
     @db_retry
     async def delete_session(self, session_id: str) -> bool:
@@ -638,20 +681,39 @@ class PostgreSQLBackend(BaseDatabaseBackend):
 
         Returns the most-recent match (ORDER BY started_at DESC LIMIT 1), or None
         if no matching session exists.
+
+        Issue #69: when status == 'active', excludes sessions older than
+        get_session_max_age_hours() -- same staleness guard as
+        get_active_session_for_project, applied here too so this lookup can't
+        reintroduce the abandoned-session-resurrection bug by a second path.
         """
         pool = self._ensure_connected()
 
         async with pool.acquire() as conn:
-            row = await conn.fetchrow(
-                """
-                SELECT * FROM sessions
-                WHERE project_name = $1 AND status = $2
-                ORDER BY started_at DESC
-                LIMIT 1
-                """,
-                project_name,
-                status,
-            )
+            if status == "active":
+                cutoff = datetime.now(UTC) - timedelta(hours=get_session_max_age_hours())
+                row = await conn.fetchrow(
+                    """
+                    SELECT * FROM sessions
+                    WHERE project_name = $1 AND status = $2 AND started_at >= $3
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                    """,
+                    project_name,
+                    status,
+                    cutoff,
+                )
+            else:
+                row = await conn.fetchrow(
+                    """
+                    SELECT * FROM sessions
+                    WHERE project_name = $1 AND status = $2
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                    """,
+                    project_name,
+                    status,
+                )
             if row:
                 return self._normalize_session_data(self._from_record(row))
             return None

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -13,13 +13,13 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 import aiosqlite
 
-from .base import DEFAULT_SQLITE_PATH, BaseDatabaseBackend
+from .base import DEFAULT_SQLITE_PATH, BaseDatabaseBackend, get_session_max_age_hours
 
 logger = logging.getLogger(__name__)
 
@@ -490,22 +490,53 @@ class SQLiteBackend(BaseDatabaseBackend):
         return [self._normalize_session_data(dict(row)) for row in rows]
 
     async def get_active_session_for_project(self, project_path: str) -> dict[str, Any] | None:
-        """Get the most recent active session for a project path."""
+        """Get the most recent active session for a project path.
+
+        Issue #69: excludes sessions older than get_session_max_age_hours() so a
+        session abandoned without an explicit finalize is not resurrected as the
+        current session for new work. See get_session_max_age_hours() for the
+        started_at-only staleness caveat.
+        """
         conn = self._ensure_connected()
+        cutoff = (datetime.now(UTC) - timedelta(hours=get_session_max_age_hours())).isoformat()
 
         cursor = await conn.execute(
             """
             SELECT * FROM sessions
-            WHERE project_path = ? AND status = 'active'
+            WHERE project_path = ? AND status = 'active' AND started_at >= ?
             ORDER BY started_at DESC
             LIMIT 1
             """,
-            (project_path,),
+            (project_path, cutoff),
         )
         row = await cursor.fetchone()
         if row:
             return self._normalize_session_data(dict(row))
         return None
+
+    async def reap_abandoned_sessions(self, older_than_hours: int | None = None) -> int:
+        """Flip stale 'active' sessions to 'abandoned'. Returns rows affected.
+
+        Issue #69: run once at server startup so no process resurrects a
+        months-old 'active' session via get_active_session_for_project /
+        find_recent_session_by_project. Uses 'abandoned', not 'completed', so
+        the data stays honest about never having been finalized. See
+        get_session_max_age_hours() for the started_at-only staleness caveat.
+        """
+        conn = self._ensure_connected()
+        hours = older_than_hours if older_than_hours is not None else get_session_max_age_hours()
+        cutoff = (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+
+        cursor = await conn.execute(
+            """
+            UPDATE sessions
+            SET status = 'abandoned'
+            WHERE status = 'active' AND started_at < ?
+            """,
+            (cutoff,),
+        )
+        await conn.commit()
+        return cursor.rowcount
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session by ID."""
@@ -570,18 +601,37 @@ class SQLiteBackend(BaseDatabaseBackend):
 
         Returns the most-recent match (ORDER BY started_at DESC LIMIT 1), or None
         if no matching session exists.
+
+        Issue #69: when status == 'active', excludes sessions older than
+        get_session_max_age_hours() -- same staleness guard as
+        get_active_session_for_project, applied here too so this lookup can't
+        reintroduce the abandoned-session-resurrection bug by a second path.
         """
         conn = self._ensure_connected()
 
-        cursor = await conn.execute(
-            """
-            SELECT * FROM sessions
-            WHERE project_name = ? AND status = ?
-            ORDER BY started_at DESC
-            LIMIT 1
-            """,
-            (project_name, status),
-        )
+        if status == "active":
+            cutoff = (
+                datetime.now(UTC) - timedelta(hours=get_session_max_age_hours())
+            ).isoformat()
+            cursor = await conn.execute(
+                """
+                SELECT * FROM sessions
+                WHERE project_name = ? AND status = ? AND started_at >= ?
+                ORDER BY started_at DESC
+                LIMIT 1
+                """,
+                (project_name, status, cutoff),
+            )
+        else:
+            cursor = await conn.execute(
+                """
+                SELECT * FROM sessions
+                WHERE project_name = ? AND status = ?
+                ORDER BY started_at DESC
+                LIMIT 1
+                """,
+                (project_name, status),
+            )
 
         row = await cursor.fetchone()
         if row:

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -189,6 +189,14 @@ class HTTPSessionIntelligenceServer:
             database=self.database,  # Pass database for persistence
         )
 
+        # Issue #69: sweep stale 'active' sessions to 'abandoned' once per process
+        # start, BEFORE checking for a resumable session below. Without this,
+        # get_active_session_for_project's staleness guard only hides old rows
+        # from reads -- they never leave status='active' in the DB.
+        reaped_count = await self.database.reap_abandoned_sessions()
+        if reaped_count:
+            logger.info(f"Reaped {reaped_count} abandoned session(s) (status: active -> abandoned)")
+
         # Session continuity: Check for active session for this project
         active_session = await self.database.get_active_session_for_project(self.repository_path)
         if active_session:

--- a/tests/regression/test_issue_69_reap_abandoned_sessions.py
+++ b/tests/regression/test_issue_69_reap_abandoned_sessions.py
@@ -1,0 +1,193 @@
+"""
+Regression tests for issue #69: nothing ever transitioned an abandoned
+session out of status='active'. Sessions only became 'completed' via an
+explicit finalize, so any Claude session ending without one stayed 'active'
+forever. get_active_session_for_project (and find_recent_session_by_project)
+then loaded a MONTHS-OLD row as "the" active session for a project, silently
+attaching new work to a stale session's lineage.
+
+Fix:
+- New SessionStatus.ABANDONED, distinct from COMPLETED -- the data stays
+  honest about never having been finalized.
+- get_active_session_for_project / find_recent_session_by_project(status=
+  "active") now exclude sessions older than get_session_max_age_hours()
+  (default 24h, overridable via SESSION_INTELLIGENCE_SESSION_MAX_AGE_HOURS).
+- New reap_abandoned_sessions() flips stale 'active' rows to 'abandoned' and
+  is called once at HTTP transport startup.
+
+Uses the SQLite backend directly, following the existing regression-test
+style (see test_issue_77_finalize_scope_binding.py).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from persistence.base import DEFAULT_SESSION_MAX_AGE_HOURS
+from persistence.sqlite import SQLiteBackend
+
+
+def _session_dict(
+    *,
+    status: str = "active",
+    age_hours: float = 0.0,
+    project_path: str = "/tmp/proj",
+    project_name: str = "proj",
+) -> dict:
+    """Build a raw session dict ready for SQLiteBackend.save_session.
+
+    age_hours controls how far in the past started_at is set, so tests can
+    place a session on either side of the staleness threshold.
+    """
+    sid = f"session-{uuid.uuid4().hex[:8]}"
+    started_at = datetime.now(UTC) - timedelta(hours=age_hours)
+    return {
+        "id": sid,
+        "started_at": started_at.isoformat(),
+        "ended_at": None,
+        "project_path": project_path,
+        "project_name": project_name,
+        "mode": "local",
+        "status": status,
+        "metadata": {},
+        "performance_metrics": {},
+        "health_status": {},
+    }
+
+
+@pytest.mark.regression
+class TestGetActiveSessionForProjectExcludesStale:
+    @pytest.fixture
+    async def backend(self, tmp_path):
+        db = SQLiteBackend(str(tmp_path / "test.db"))
+        await db.initialize()
+        yield db
+        await db.close()
+
+    async def test_stale_active_session_not_returned(self, backend):
+        stale = _session_dict(age_hours=DEFAULT_SESSION_MAX_AGE_HOURS + 1)
+        await backend.save_session(stale)
+
+        result = await backend.get_active_session_for_project(stale["project_path"])
+
+        assert result is None, (
+            "Issue #69: a stale 'active' session must not be resurrected as "
+            "the current session for its project."
+        )
+
+    async def test_fresh_active_session_is_returned(self, backend):
+        fresh = _session_dict(age_hours=1)
+        await backend.save_session(fresh)
+
+        result = await backend.get_active_session_for_project(fresh["project_path"])
+
+        assert result is not None
+        assert result["id"] == fresh["id"]
+
+
+@pytest.mark.regression
+class TestFindRecentSessionByProjectExcludesStale:
+    @pytest.fixture
+    async def backend(self, tmp_path):
+        db = SQLiteBackend(str(tmp_path / "test.db"))
+        await db.initialize()
+        yield db
+        await db.close()
+
+    async def test_stale_active_session_excluded(self, backend):
+        stale = _session_dict(
+            age_hours=DEFAULT_SESSION_MAX_AGE_HOURS + 1, project_name="proj-x"
+        )
+        await backend.save_session(stale)
+
+        result = await backend.find_recent_session_by_project("proj-x", status="active")
+
+        assert result is None, (
+            "find_recent_session_by_project must apply the same staleness "
+            "guard as get_active_session_for_project, or the bug is "
+            "reintroduced by a second path."
+        )
+
+    async def test_fresh_active_session_returned(self, backend):
+        fresh = _session_dict(age_hours=1, project_name="proj-y")
+        await backend.save_session(fresh)
+
+        result = await backend.find_recent_session_by_project("proj-y", status="active")
+
+        assert result is not None
+        assert result["id"] == fresh["id"]
+
+    async def test_non_active_status_lookup_unaffected_by_staleness(self, backend):
+        old_completed = _session_dict(
+            status="completed",
+            age_hours=DEFAULT_SESSION_MAX_AGE_HOURS + 100,
+            project_name="proj-z",
+        )
+        await backend.save_session(old_completed)
+
+        result = await backend.find_recent_session_by_project("proj-z", status="completed")
+
+        assert result is not None
+        assert result["id"] == old_completed["id"]
+
+
+@pytest.mark.regression
+class TestReapAbandonedSessions:
+    @pytest.fixture
+    async def backend(self, tmp_path):
+        db = SQLiteBackend(str(tmp_path / "test.db"))
+        await db.initialize()
+        yield db
+        await db.close()
+
+    async def test_reap_flips_only_stale_active_rows(self, backend):
+        stale = _session_dict(age_hours=DEFAULT_SESSION_MAX_AGE_HOURS + 1, project_name="p1")
+        fresh = _session_dict(age_hours=1, project_name="p2")
+        stale_but_completed = _session_dict(
+            status="completed",
+            age_hours=DEFAULT_SESSION_MAX_AGE_HOURS + 100,
+            project_name="p3",
+        )
+        await backend.save_session(stale)
+        await backend.save_session(fresh)
+        await backend.save_session(stale_but_completed)
+
+        reaped = await backend.reap_abandoned_sessions()
+
+        assert reaped == 1, "Only the stale 'active' row should be reaped."
+
+        stale_row = await backend.get_session(stale["id"])
+        fresh_row = await backend.get_session(fresh["id"])
+        completed_row = await backend.get_session(stale_but_completed["id"])
+
+        assert stale_row["status"] == "abandoned", (
+            "Issue #69: reaped rows must become 'abandoned', NOT 'completed' "
+            "-- the distinction is the point: this session was never "
+            "explicitly finalized."
+        )
+        assert fresh_row["status"] == "active"
+        assert completed_row["status"] == "completed"
+
+    async def test_reap_respects_custom_older_than_hours(self, backend):
+        borderline = _session_dict(age_hours=5, project_name="p4")
+        await backend.save_session(borderline)
+
+        # Threshold tighter than default: a 5h-old session now counts as stale.
+        reaped = await backend.reap_abandoned_sessions(older_than_hours=1)
+
+        assert reaped == 1
+        row = await backend.get_session(borderline["id"])
+        assert row["status"] == "abandoned"
+
+    async def test_reap_returns_zero_when_nothing_stale(self, backend):
+        fresh = _session_dict(age_hours=1, project_name="p5")
+        await backend.save_session(fresh)
+
+        reaped = await backend.reap_abandoned_sessions()
+
+        assert reaped == 0
+        row = await backend.get_session(fresh["id"])
+        assert row["status"] == "active"


### PR DESCRIPTION
## Problem

Nothing ever transitioned an abandoned session out of `status='active'`. Sessions only became `completed` via an explicit finalize call, so any Claude session ending without one stayed `active` forever. As of 2026-08-15: 630 sessions active, 615 of them >1 day old (dating back to Dec 2025), collectively owning 10,708 `agent_executions` (73% of that table).

`get_active_session_for_project(project_path)` does:
```sql
SELECT * FROM sessions WHERE project_path=$1 AND status='active' ORDER BY started_at DESC LIMIT 1
```
So for any project whose last session was abandoned, a MONTHS-OLD row got loaded into `session_cache` as the current session and re-persisted from there -- silently attaching new work to a stale session's lineage.

## Fix

- **New `SessionStatus.ABANDONED`**, distinct from `COMPLETED` -- the data stays honest about a session having never been explicitly finalized.
- **Read-path guard**: `get_active_session_for_project` and `find_recent_session_by_project(status="active")` now exclude sessions older than a staleness threshold, in **both** the PostgreSQL and SQLite backends.
- **Startup sweep**: new `reap_abandoned_sessions(older_than_hours)` backend method flips stale `'active'` rows to `'abandoned'` (never `'completed'`) and returns the row count. Called once at HTTP transport startup (`lifespan()`), before the resume-active-session check; the reaped count is logged.
- **Threshold**: defaults to 24h, defined once in `persistence.base.get_session_max_age_hours()` and used by both the read guard and the sweep so they cannot drift apart. Overridable via `SESSION_INTELLIGENCE_SESSION_MAX_AGE_HOURS`.

## Deferred limitation

`started_at` is the only staleness signal available today, so a genuinely long-lived session past the threshold is indistinguishable from an abandoned one and gets incorrectly excluded/reaped. A `last_seen_at` heartbeat column would fix this but requires a schema migration -- noted in code comments at every threshold application site, not fixed in this PR.

## Migration script

`scripts/migrations/reap_stale_active_sessions.py` is a ONE-TIME cleanup for rows that were already stale before this fix ships (the app-level fix only takes effect going forward / on process restart). It is DRY-RUN by default, reports counts grouped by month, and requires `--apply` to write.

**Per explicit product decision, this script is checked in but has NOT been executed against any database, including in dry-run mode, as part of landing this fix.**

## Tests

`tests/regression/test_issue_69_reap_abandoned_sessions.py` covers:
- Stale `active` sessions excluded from `get_active_session_for_project` / `find_recent_session_by_project`, fresh ones still returned
- `reap_abandoned_sessions` flips only stale `active` rows (never `completed` rows or fresh `active` rows) and returns the correct count
- Reaped rows land on `'abandoned'`, NOT `'completed'`
- Custom `older_than_hours` override

## Verification

`pixi run -e ci test`: **563 passed, 74 skipped** (baseline 555 passed + 8 new tests, 0 failures)
`pixi run -e ci lint`: **All checks passed!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)