### PR TITLE
fix(session): reconcile executions that never report a stop event (closes #70)

### DIFF
--- a/scripts/migrations/reap_stale_executions.py
+++ b/scripts/migrations/reap_stale_executions.py
@@ -1,0 +1,233 @@
+"""One-time reap of pre-existing stale 'running' agent_executions (issue #70).
+
+Background:
+    Issue #39/#40 fixed the common case of AgentExecution status never
+    transitioning out of RUNNING by having the SubagentStop hook
+    (phase == "agent_stop") flip it to SUCCESS/ERROR. That fix is incomplete:
+    if the stop event never arrives -- agent killed, session ends mid-flight,
+    hook fails or times out, server restart between start and stop -- the row
+    stays 'running' forever. As of 2026-08-15, 847 executions started AFTER
+    the #40 fix are still 'running', alongside 13,688 'success'. Because
+    get_agent_stats counted every row toward the success_rate denominator
+    regardless of status, these rows silently understated success_rate for
+    every agent -- the exact metric #39 existed to fix.
+
+    The application-level fix is two-pronged:
+    - reconcile-on-finalize: session_engine._finalize_session now flips any
+      still-RUNNING execution (and its still-running execution_steps) to
+      ABANDONED before the session is persisted.
+    - reap_stale_executions(), called once at HTTP transport startup (mirrors
+      reap_abandoned_sessions from issue #69), catches executions whose
+      session was never explicitly finalized either (crash, restart, etc).
+    Both only take effect going forward and on process restart/finalize. This
+    script is a ONE-TIME cleanup for rows that were already stale before the
+    fix shipped. It intentionally duplicates the app's UPDATE rather than
+    calling reap_stale_executions() directly, so it can run standalone
+    (dry-run) without importing the full server stack.
+
+Known limitation (same caveat as issue #69, see persistence/base.py
+get_execution_max_age_hours()):
+    started_at is the only staleness signal available today. A genuinely
+    long-running execution that has stayed open past --older-than-hours will
+    be incorrectly flagged as abandoned.
+
+Safety:
+    - Default mode is DRY-RUN (report only, no writes).
+    - --apply is required to write. There is no additional confirmation flag
+      by design (this script is invoked deliberately, unlike the interactive
+      backfill scripts) -- but per project policy this script is checked in
+      and is NOT to be executed against the production database as part of
+      landing this fix. Running it (even in dry-run) against production is a
+      separate, explicit operational decision.
+    - Rows are flipped to 'abandoned', NEVER 'error' -- the distinction is
+      the point: "never reported a stop event" is not "failed".
+
+Usage (report only, safe to run anytime):
+    PYTHONPATH=src python scripts/migrations/reap_stale_executions.py
+
+Usage (apply, default 24h threshold):
+    PYTHONPATH=src python scripts/migrations/reap_stale_executions.py --apply
+
+Usage (custom threshold):
+    PYTHONPATH=src python scripts/migrations/reap_stale_executions.py \
+        --older-than-hours 72
+
+Environment variables:
+    SESSION_DB_DSN  PostgreSQL DSN (same variable the application reads via
+                     persistence.config.DatabaseConfig; falls back to
+                     DEFAULT_POSTGRES_DSN like the app does if unset)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import urllib.parse
+from datetime import UTC, datetime, timedelta
+
+from persistence.base import DEFAULT_EXECUTION_MAX_AGE_HOURS
+from persistence.config import DatabaseConfig
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def get_db_name(dsn: str) -> str:
+    """Extract the database name from a PostgreSQL DSN for operator confirmation."""
+    parsed = urllib.parse.urlparse(dsn)
+    return parsed.path.lstrip("/") or "(unspecified)"
+
+
+def print_month_summary(month_counts: dict[str, int], total: int, label: str) -> None:
+    """Print a month -> row_count table, matching the issue's reporting format."""
+    print()
+    print(f"{label}")
+    print(f"{'month':<10} {'row_count':>10}")
+    print("-" * 21)
+    for month in sorted(month_counts):
+        print(f"{month:<10} {month_counts[month]:>10}")
+    print("-" * 21)
+    print(f"{'total':<10} {total:>10}")
+    print()
+
+
+async def reap(dsn: str, apply_changes: bool, older_than_hours: int) -> None:
+    """Report (dry-run) or apply the reap of stale 'running' agent_executions."""
+    try:
+        import asyncpg
+    except ImportError:
+        logger.error("asyncpg is required for PostgreSQL. Install with: pip install asyncpg")
+        sys.exit(1)
+
+    db_name = get_db_name(dsn)
+    logger.info(f"Target database: {db_name}")
+    logger.info(f"Staleness threshold: {older_than_hours}h")
+
+    cutoff = datetime.now(UTC) - timedelta(hours=older_than_hours)
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        total_running = await conn.fetchval(
+            "SELECT COUNT(*) FROM agent_executions WHERE status = 'running'"
+        )
+        logger.info(f"Total rows currently status='running': {total_running}")
+
+        before_rows = await conn.fetch(
+            """
+            SELECT to_char(started_at, 'YYYY-MM') AS month, COUNT(*) AS row_count
+            FROM agent_executions
+            WHERE status = 'running' AND started_at < $1
+            GROUP BY month
+            ORDER BY month
+            """,
+            cutoff,
+        )
+        before_counts = {row["month"]: row["row_count"] for row in before_rows}
+        would_change = sum(before_counts.values())
+
+        print_month_summary(
+            before_counts,
+            would_change,
+            "Stale 'running' agent_executions BY MONTH (started_at < cutoff):",
+        )
+        logger.info(
+            f"{would_change} of {total_running} running rows are older than "
+            f"the {older_than_hours}h threshold and would move to 'abandoned'."
+        )
+
+        if not apply_changes:
+            logger.info(
+                "DRY RUN complete — no changes written. Re-run with --apply to write."
+            )
+            return
+
+        result = await conn.execute(
+            """
+            UPDATE agent_executions
+            SET status = 'abandoned', completed_at = COALESCE(completed_at, NOW())
+            WHERE status = 'running' AND started_at < $1
+            """,
+            cutoff,
+        )
+        try:
+            updated = int(result.split()[-1])
+        except (IndexError, ValueError):
+            updated = 0
+
+        remaining_running = await conn.fetchval(
+            "SELECT COUNT(*) FROM agent_executions WHERE status = 'running'"
+        )
+        total_abandoned = await conn.fetchval(
+            "SELECT COUNT(*) FROM agent_executions WHERE status = 'abandoned'"
+        )
+        logger.info(f"APPLY complete: {updated} rows moved to 'abandoned'.")
+        logger.info(f"Remaining status='running' rows: {remaining_running}")
+        logger.info(f"Total status='abandoned' rows: {total_abandoned}")
+    finally:
+        await conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reap pre-existing stale 'running' agent_executions to 'abandoned' "
+            "(one-time cleanup for issue #70). Dry-run by default."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help=(
+            "PostgreSQL DSN. Defaults to the same config the app uses "
+            "(SESSION_DB_DSN env var, or DEFAULT_POSTGRES_DSN)."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report only, never write (default mode)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the UPDATE. Not run as part of shipping this fix; a separate, "
+        "explicit operational decision.",
+    )
+    parser.add_argument(
+        "--older-than-hours",
+        type=int,
+        default=DEFAULT_EXECUTION_MAX_AGE_HOURS,
+        help=f"Staleness threshold in hours (default: {DEFAULT_EXECUTION_MAX_AGE_HOURS})",
+    )
+    args = parser.parse_args()
+
+    if not args.dsn:
+        args.dsn = (
+            DatabaseConfig.load().postgresql_dsn
+            or os.environ.get("SESSION_DB_DSN")
+        )
+    if not args.dsn:
+        from persistence.base import DEFAULT_POSTGRES_DSN
+
+        args.dsn = DEFAULT_POSTGRES_DSN
+
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(
+        reap(
+            args.dsn,
+            apply_changes=args.apply,
+            older_than_hours=args.older_than_hours,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/session_engine.py
+++ b/src/core/session_engine.py
@@ -870,6 +870,37 @@ class SessionIntelligenceEngine:
         total_time = (session.completed - session.started).total_seconds() * 1000
         session.performance_metrics.total_execution_time_ms = int(total_time)
 
+        # Issue #70: reconcile executions that never reported a stop event.
+        # #40 only transitions an AgentExecution out of RUNNING when the
+        # SubagentStop hook fires (phase == "agent_stop"). If that event never
+        # arrives -- agent killed, hook fails/times out, session ends
+        # mid-flight -- the row stays RUNNING forever, permanently inflating
+        # the success_rate denominator (see get_agent_stats). ABANDONED is
+        # distinct from ERROR: "never reported" is not "failed". This must
+        # happen BEFORE the session is persisted below, and each reconciled
+        # execution must also be persisted individually since agent_executions
+        # is a separate table from sessions.
+        reconciled_at = session.completed
+        for agent_exec in session.agents_executed:
+            if agent_exec.status != ExecutionStatus.RUNNING:
+                continue
+            agent_exec.status = ExecutionStatus.ABANDONED
+            agent_exec.completed = reconciled_at
+            for step in agent_exec.execution_steps:
+                if step.status == ExecutionStatus.RUNNING:
+                    step.status = ExecutionStatus.ABANDONED
+                    step.completed = reconciled_at
+            if self.database:
+                try:
+                    exec_data = agent_exec.model_dump(mode="python")
+                    exec_data["session_id"] = session_id
+                    await self.database.save_agent_execution(exec_data)
+                except Exception as e:
+                    debug_logger.error(
+                        f"Error persisting reconciled (abandoned) execution "
+                        f"{agent_exec.execution_id}: {e}"
+                    )
+
         # Persist completed status to DB (issue #25 Bug 1). Without this,
         # the row stays status='active' forever and stale sessions keep
         # matching find_recent_session_by_project lookups.

--- a/src/models/session_models.py
+++ b/src/models/session_models.py
@@ -32,6 +32,7 @@ class ExecutionStatus(StrEnum):
     SUCCESS = "success"
     ERROR = "error"
     SKIPPED = "skipped"
+    ABANDONED = "abandoned"  # Issue #70: never reported agent_stop; distinct from ERROR
 
 
 class ImpactLevel(StrEnum):

--- a/src/persistence/base.py
+++ b/src/persistence/base.py
@@ -51,6 +51,29 @@ def get_session_max_age_hours() -> int:
         return DEFAULT_SESSION_MAX_AGE_HOURS
 
 
+# Issue #70: staleness threshold (hours) for 'running' agent_executions. The
+# SubagentStop hook ("agent_stop" phase) is the only signal that transitions
+# an execution out of RUNNING (see session_engine.py). If that event never
+# arrives -- agent killed, session ends mid-flight, hook fails/times out,
+# server restart between start and stop -- the row stays 'running' forever,
+# permanently inflating the success_rate denominator (see get_agent_stats).
+# Mirrors DEFAULT_SESSION_MAX_AGE_HOURS / get_session_max_age_hours() exactly
+# so the two staleness sweeps cannot drift apart in behavior. Overridable via
+# SESSION_INTELLIGENCE_EXECUTION_MAX_AGE_HOURS.
+DEFAULT_EXECUTION_MAX_AGE_HOURS = 24
+
+
+def get_execution_max_age_hours() -> int:
+    """Return the staleness threshold (hours) for 'running' agent_executions."""
+    raw = os.environ.get("SESSION_INTELLIGENCE_EXECUTION_MAX_AGE_HOURS")
+    if raw is None:
+        return DEFAULT_EXECUTION_MAX_AGE_HOURS
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_EXECUTION_MAX_AGE_HOURS
+
+
 def get_default_data_dir() -> Path:
     """Get the default data directory, creating it if needed."""
     DEFAULT_DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -189,6 +212,17 @@ class DatabaseBackend(Protocol):
         Distinct from 'completed': an abandoned session never received an
         explicit finalize call, so the status stays honest about that.
         Defaults to get_session_max_age_hours() when older_than_hours is None.
+        """
+        ...
+
+    async def reap_stale_executions(self, older_than_hours: int | None = None) -> int:
+        """Flip stale 'running' agent_executions to 'abandoned'. Returns rows affected.
+
+        Issue #70: reconcile-on-finalize (see session_engine._finalize_session)
+        catches executions whose session was explicitly finalized; this sweep
+        catches the rest (server restart, crash, etc.) so no execution stays
+        'running' forever. Defaults to get_execution_max_age_hours() when
+        older_than_hours is None.
         """
         ...
 

--- a/src/persistence/postgresql.py
+++ b/src/persistence/postgresql.py
@@ -30,6 +30,7 @@ from .base import (
     DEFAULT_POSTGRES_DSN,
     BaseDatabaseBackend,
     db_retry,
+    get_execution_max_age_hours,
     get_session_max_age_hours,
     sanitize_dsn,
 )
@@ -184,7 +185,10 @@ class PostgreSQLBackend(BaseDatabaseBackend):
         COUNT(CASE WHEN status = 'error' THEN 1 END) as failed,
         AVG(EXTRACT(EPOCH FROM (completed_at - started_at))) as avg_duration_seconds
     FROM agent_executions
-    WHERE completed_at IS NOT NULL
+    -- Issue #70: 'abandoned' executions never reported a stop event and are
+    -- unknown, not failed -- excluded from the denominator entirely so they
+    -- cannot silently understate the success rate.
+    WHERE completed_at IS NOT NULL AND status != 'abandoned'
     GROUP BY agent_name;
 
     CREATE OR REPLACE VIEW decision_summary AS
@@ -610,6 +614,32 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 UPDATE sessions
                 SET status = 'abandoned'
                 WHERE status = 'active' AND started_at < $1
+                """,
+                cutoff,
+            )
+            try:
+                return int(result.split()[-1])
+            except (IndexError, ValueError):
+                return 0
+
+    @db_retry
+    async def reap_stale_executions(self, older_than_hours: int | None = None) -> int:
+        """Flip stale 'running' agent_executions to 'abandoned'. Returns rows affected.
+
+        Issue #70: run once at server startup, alongside reap_abandoned_sessions,
+        so an execution whose stop event never arrives doesn't stay 'running'
+        forever and inflate the success_rate denominator (see get_agent_stats).
+        """
+        pool = self._ensure_connected()
+        hours = older_than_hours if older_than_hours is not None else get_execution_max_age_hours()
+        cutoff = datetime.now(UTC) - timedelta(hours=hours)
+
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                """
+                UPDATE agent_executions
+                SET status = 'abandoned', completed_at = COALESCE(completed_at, NOW())
+                WHERE status = 'running' AND started_at < $1
                 """,
                 cutoff,
             )
@@ -1436,6 +1466,7 @@ class PostgreSQLBackend(BaseDatabaseBackend):
                 SELECT agent_type, agent_name, status, performance, started_at, completed_at
                 FROM agent_executions
                 WHERE started_at >= NOW() - ($1 * INTERVAL '1 hour')
+                    AND status != 'abandoned'
                 ORDER BY started_at DESC
                 """,
                 time_window_hours,

--- a/src/persistence/sqlite.py
+++ b/src/persistence/sqlite.py
@@ -19,7 +19,12 @@ from typing import Any
 
 import aiosqlite
 
-from .base import DEFAULT_SQLITE_PATH, BaseDatabaseBackend, get_session_max_age_hours
+from .base import (
+    DEFAULT_SQLITE_PATH,
+    BaseDatabaseBackend,
+    get_execution_max_age_hours,
+    get_session_max_age_hours,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -534,6 +539,28 @@ class SQLiteBackend(BaseDatabaseBackend):
             WHERE status = 'active' AND started_at < ?
             """,
             (cutoff,),
+        )
+        await conn.commit()
+        return cursor.rowcount
+
+    async def reap_stale_executions(self, older_than_hours: int | None = None) -> int:
+        """Flip stale 'running' agent_executions to 'abandoned'. Returns rows affected.
+
+        Issue #70: see postgresql.py counterpart for rationale. Run once at
+        server startup, alongside reap_abandoned_sessions.
+        """
+        conn = self._ensure_connected()
+        hours = older_than_hours if older_than_hours is not None else get_execution_max_age_hours()
+        cutoff = (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+        now = datetime.now(UTC).isoformat()
+
+        cursor = await conn.execute(
+            """
+            UPDATE agent_executions
+            SET status = 'abandoned', completed_at = COALESCE(completed_at, ?)
+            WHERE status = 'running' AND started_at < ?
+            """,
+            (now, cutoff),
         )
         await conn.commit()
         return cursor.rowcount
@@ -1074,7 +1101,7 @@ class SQLiteBackend(BaseDatabaseBackend):
             """
             SELECT agent_type, agent_name, status, performance, started_at, completed_at
             FROM agent_executions
-            WHERE started_at >= ?
+            WHERE started_at >= ? AND status != 'abandoned'
             ORDER BY started_at DESC
             """,
             (cutoff,),

--- a/src/transport/http_server.py
+++ b/src/transport/http_server.py
@@ -197,6 +197,18 @@ class HTTPSessionIntelligenceServer:
         if reaped_count:
             logger.info(f"Reaped {reaped_count} abandoned session(s) (status: active -> abandoned)")
 
+        # Issue #70: sweep stale 'running' agent_executions to 'abandoned', same
+        # rationale as reap_abandoned_sessions above -- catches executions whose
+        # stop event never arrived (crash, restart, killed agent) and that
+        # reconcile-on-finalize (session_engine._finalize_session) could not
+        # reach because their session was never explicitly finalized either.
+        reaped_executions_count = await self.database.reap_stale_executions()
+        if reaped_executions_count:
+            logger.info(
+                f"Reaped {reaped_executions_count} stale agent execution(s) "
+                "(status: running -> abandoned)"
+            )
+
         # Session continuity: Check for active session for this project
         active_session = await self.database.get_active_session_for_project(self.repository_path)
         if active_session:

--- a/tests/regression/test_issue_70_reconcile_stuck_executions.py
+++ b/tests/regression/test_issue_70_reconcile_stuck_executions.py
@@ -1,0 +1,327 @@
+"""
+Regression tests for issue #70: AgentExecution status permanently stuck at
+RUNNING when the SubagentStop hook never reports a stop event.
+
+https://github.com/Claire-s-Monster/session-intelligence/issues/70
+
+Background:
+    #40 (issue #39) transitions an AgentExecution out of RUNNING only when
+    the SubagentStop hook reports phase == "agent_stop" (see
+    session_engine.session_track_execution). If that event never arrives --
+    agent killed, session ends mid-flight, hook fails or times out, server
+    restart between start and stop -- the row keeps the Pydantic default
+    RUNNING forever. As of 2026-08-15, 847 executions started AFTER the #40
+    fix were still 'running'. Because get_agent_stats counted every row
+    toward the success_rate denominator regardless of status, these rows
+    silently understated success_rate for every agent -- the exact metric
+    #39 existed to fix.
+
+Fix:
+- New ExecutionStatus.ABANDONED, distinct from ERROR: "never reported" is
+  not "failed".
+- session_engine._finalize_session now reconciles any still-RUNNING
+  AgentExecution (and its still-running ExecutionSteps) to ABANDONED before
+  persisting the session, and persists each reconciled execution
+  individually (agent_executions is a separate table from sessions).
+- New reap_stale_executions() backend method (both SQLite and PostgreSQL)
+  flips stale 'running' rows to 'abandoned' at HTTP transport startup,
+  mirroring issue #69's reap_abandoned_sessions -- catches executions whose
+  session was never explicitly finalized either.
+- get_agent_stats (both backends) now excludes 'abandoned' rows from the
+  success_rate denominator entirely, rather than counting them as
+  non-successes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from core.session_engine import SessionIntelligenceEngine
+from models.session_models import ExecutionStatus
+from persistence.base import DEFAULT_EXECUTION_MAX_AGE_HOURS
+from persistence.sqlite import SQLiteBackend
+
+AGENT_NAME = "focused-code-modifier"
+
+
+def _session_dict(
+    *, status: str = "active", project_path: str = "/tmp/proj", project_name: str = "proj"
+) -> dict:
+    """Build a raw session dict ready for SQLiteBackend.save_session.
+
+    agent_executions has a FOREIGN KEY on session_id, enforced (PRAGMA
+    foreign_keys=ON), so tests inserting raw execution rows need a real
+    session row to reference first.
+    """
+    sid = f"session-{uuid.uuid4().hex[:8]}"
+    return {
+        "id": sid,
+        "started_at": datetime.now(UTC).isoformat(),
+        "ended_at": None,
+        "project_path": project_path,
+        "project_name": project_name,
+        "mode": "local",
+        "status": status,
+        "metadata": {},
+        "performance_metrics": {},
+        "health_status": {},
+    }
+
+
+def _execution_dict(
+    *,
+    session_id: str,
+    status: str = "running",
+    age_hours: float = 0.0,
+    agent_name: str = AGENT_NAME,
+    agent_type: str = "focused",
+) -> dict:
+    """Build a raw agent_executions dict ready for SQLiteBackend.save_agent_execution."""
+    started_at = datetime.now(UTC) - timedelta(hours=age_hours)
+    return {
+        "id": f"exec-{uuid.uuid4().hex[:8]}",
+        "session_id": session_id,
+        "agent_name": agent_name,
+        "agent_type": agent_type,
+        "started_at": started_at.isoformat(),
+        "completed_at": None,
+        "status": status,
+        "execution_steps": [],
+        "performance": {},
+        "errors": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reconcile-on-finalize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestFinalizeReconcilesRunningExecutions:
+    """Finalizing a session must flip its still-RUNNING executions to
+    ABANDONED, not leave them RUNNING and not misreport them as ERROR/SUCCESS."""
+
+    @pytest.fixture
+    async def engine(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SESSION_INTELLIGENCE_AGENT_VALIDATION", "off")
+        db = SQLiteBackend(str(tmp_path / "test.db"))
+        await db.initialize()
+        eng = SessionIntelligenceEngine(
+            repository_path=str(tmp_path), use_filesystem=False, database=db
+        )
+        yield eng
+        await db.close()
+
+    async def _start_agent(self, engine):
+        # Create via session_manage_lifecycle (not session_track_execution's
+        # auto-create path) so the session row is persisted to the DB --
+        # finalize-by-session_id requires database.get_session() to resolve
+        # it (see _resolve_session_context).
+        create_result = await engine.session_manage_lifecycle(
+            operation="create", mode="local", project_name="proj-70"
+        )
+        session_id = create_result.session_id
+
+        start_result = await engine.session_track_execution(
+            session_id=session_id,
+            agent_name=AGENT_NAME,
+            step_data={"operation": "start", "description": "SubagentStart hook"},
+        )
+        assert start_result.status == "success"
+        return session_id
+
+    async def test_running_execution_becomes_abandoned_on_finalize(self, engine):
+        session_id = await self._start_agent(engine)
+
+        session = engine.session_cache[session_id]
+        agent_execution = next(
+            a for a in session.agents_executed if a.agent_name == AGENT_NAME
+        )
+        assert agent_execution.status == ExecutionStatus.RUNNING
+
+        finalize_result = await engine.session_manage_lifecycle(
+            operation="finalize", session_id=session_id
+        )
+        assert finalize_result.status == "success"
+
+        rows = await engine.database.query_agent_executions(session_id=session_id)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "abandoned", (
+            "Issue #70: an execution that never received agent_stop must "
+            "become 'abandoned' on finalize -- not 'error' (it never failed) "
+            "and not stuck at 'running'."
+        )
+        assert rows[0]["completed_at"] is not None
+
+    async def test_success_execution_untouched_by_finalize(self, engine):
+        """An execution that DID receive agent_stop with success=True must
+        not be disturbed by finalize-time reconciliation (no regression of
+        #40). Only still-RUNNING executions are reconciled (and thereby
+        (re-)persisted); a terminal execution is left exactly as it was, so
+        assert against the in-memory object itself rather than the DB (which
+        finalize has no reason to touch for an already-terminal row)."""
+        session_id = await self._start_agent(engine)
+
+        await engine.session_track_execution(
+            session_id=session_id,
+            agent_name=AGENT_NAME,
+            step_data={"phase": "agent_stop", "agent_type": "focused", "success": True},
+        )
+        session = engine.session_cache[session_id]
+        agent_execution = next(
+            a for a in session.agents_executed if a.agent_name == AGENT_NAME
+        )
+        assert agent_execution.status == ExecutionStatus.SUCCESS
+        completed_before = agent_execution.completed
+
+        finalize_result = await engine.session_manage_lifecycle(
+            operation="finalize", session_id=session_id
+        )
+        assert finalize_result.status == "success"
+
+        assert agent_execution.status == ExecutionStatus.SUCCESS, (
+            "Finalize must not touch an already-terminal execution."
+        )
+        assert agent_execution.completed == completed_before
+
+    async def test_error_execution_untouched_by_finalize(self, engine):
+        """An execution that DID receive agent_stop with success=False must
+        stay ERROR, not get reclassified as ABANDONED by finalize."""
+        session_id = await self._start_agent(engine)
+
+        await engine.session_track_execution(
+            session_id=session_id,
+            agent_name=AGENT_NAME,
+            step_data={"phase": "agent_stop", "agent_type": "focused", "success": False},
+        )
+        session = engine.session_cache[session_id]
+        agent_execution = next(
+            a for a in session.agents_executed if a.agent_name == AGENT_NAME
+        )
+        assert agent_execution.status == ExecutionStatus.ERROR
+        completed_before = agent_execution.completed
+
+        finalize_result = await engine.session_manage_lifecycle(
+            operation="finalize", session_id=session_id
+        )
+        assert finalize_result.status == "success"
+
+        assert agent_execution.status == ExecutionStatus.ERROR, (
+            "Finalize must not touch an already-terminal execution."
+        )
+        assert agent_execution.completed == completed_before
+
+
+# ---------------------------------------------------------------------------
+# Staleness sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestReapStaleExecutions:
+    @pytest.fixture
+    async def backend(self, tmp_path):
+        db = SQLiteBackend(str(tmp_path / "test.db"))
+        await db.initialize()
+        yield db
+        await db.close()
+
+    async def test_reap_flips_only_stale_running_rows(self, backend):
+        session = _session_dict()
+        await backend.save_session(session)
+
+        stale = _execution_dict(
+            session_id=session["id"], age_hours=DEFAULT_EXECUTION_MAX_AGE_HOURS + 1
+        )
+        fresh = _execution_dict(session_id=session["id"], age_hours=1)
+        stale_but_success = _execution_dict(
+            session_id=session["id"],
+            status="success",
+            age_hours=DEFAULT_EXECUTION_MAX_AGE_HOURS + 100,
+        )
+        await backend.save_agent_execution(stale)
+        await backend.save_agent_execution(fresh)
+        await backend.save_agent_execution(stale_but_success)
+
+        reaped = await backend.reap_stale_executions()
+
+        assert reaped == 1, "Only the stale 'running' row should be reaped."
+
+        rows = {
+            row["id"]: row
+            for row in await backend.query_agent_executions(session_id=session["id"])
+        }
+        assert rows[stale["id"]]["status"] == "abandoned"
+        assert rows[fresh["id"]]["status"] == "running"
+        assert rows[stale_but_success["id"]]["status"] == "success"
+
+    async def test_reap_respects_custom_older_than_hours(self, backend):
+        session = _session_dict()
+        await backend.save_session(session)
+        borderline = _execution_dict(session_id=session["id"], age_hours=5)
+        await backend.save_agent_execution(borderline)
+
+        reaped = await backend.reap_stale_executions(older_than_hours=1)
+
+        assert reaped == 1
+        rows = await backend.query_agent_executions(session_id=session["id"])
+        assert rows[0]["status"] == "abandoned"
+
+    async def test_reap_returns_zero_when_nothing_stale(self, backend):
+        session = _session_dict()
+        await backend.save_session(session)
+        fresh = _execution_dict(session_id=session["id"], age_hours=1)
+        await backend.save_agent_execution(fresh)
+
+        reaped = await backend.reap_stale_executions()
+
+        assert reaped == 0
+        rows = await backend.query_agent_executions(session_id=session["id"])
+        assert rows[0]["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# THE METRIC FIX: success_rate must exclude abandoned from the denominator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestSuccessRateExcludesAbandoned:
+    @pytest.fixture
+    async def backend(self, tmp_path):
+        db = SQLiteBackend(str(tmp_path / "test.db"))
+        await db.initialize()
+        yield db
+        await db.close()
+
+    async def test_abandoned_rows_excluded_from_denominator(self, backend):
+        session = _session_dict()
+        await backend.save_session(session)
+
+        for _ in range(8):
+            await backend.save_agent_execution(
+                _execution_dict(session_id=session["id"], status="success")
+            )
+        for _ in range(2):
+            await backend.save_agent_execution(
+                _execution_dict(session_id=session["id"], status="abandoned")
+            )
+
+        stats = await backend.get_agent_stats(time_window_hours=168)
+        entry = next(a for a in stats["agents"] if a["agent_type"] == "focused")
+
+        assert entry["invocations"] == 8, (
+            "Abandoned executions must be excluded entirely from the "
+            "invocations count, not counted as a non-success."
+        )
+        assert entry["successes"] == 8
+        assert entry["successes"] / entry["invocations"] == 1.0, (
+            "Issue #70: 8 success + 2 abandoned must compute as 100% "
+            "success_rate, NOT 80%. Counting abandoned executions in the "
+            "denominator silently understates success_rate for every agent "
+            "-- the exact metric #39 existed to fix."
+        )


### PR DESCRIPTION
## Problem

#39 ("AgentExecution status never transitions from RUNNING") was fixed by #40, which transitions status on `phase == "agent_stop"` using `step_data.success`. That fix is incomplete: any execution whose stop event never arrives -- agent killed, session ends mid-flight, hook fails or times out, server restart between start and stop -- keeps the Pydantic default RUNNING forever. As of 2026-08-15, 847 executions started AFTER the #40 fix were still `running`, alongside 13,688 `success`.

Because `get_agent_stats` counted every row toward the `success_rate` denominator regardless of status, these stuck rows silently understated `success_rate` for every agent -- the exact metric #39 existed to fix.

## Fix

1. **New `ExecutionStatus.ABANDONED`**, distinct from `ERROR`: "never reported" is not "failed". Mirrors #69's `SessionStatus.ABANDONED`.
2. **Reconcile-on-finalize**: `_finalize_session` now flips any still-RUNNING `AgentExecution` (and its still-running `ExecutionStep`s) to `ABANDONED` before the session is persisted, and persists each reconciled execution individually (agent_executions is a separate table from sessions). #77 made finalize scope-aware, so this is now a correct reconcile point.
3. **Staleness sweep**: new `reap_stale_executions()` backend method (SQLite and PostgreSQL, added to the `DatabaseBackend` Protocol) flips stale `running` rows to `abandoned`, called once at HTTP transport startup alongside #69's `reap_abandoned_sessions()`. Threshold mirrors #69's `get_session_max_age_hours()` pattern exactly: `DEFAULT_EXECUTION_MAX_AGE_HOURS = 24`, overridable via `SESSION_INTELLIGENCE_EXECUTION_MAX_AGE_HOURS`.
4. **THE METRIC FIX**: `get_agent_stats` (both `postgresql.py` and `sqlite.py`) now excludes `abandoned` rows from the query entirely, so they cannot inflate the `success_rate` denominator. The `agent_performance_summary` Postgres VIEW gets the same exclusion.

### Aggregation sites found and changed
1. `PostgreSQLBackend.get_agent_stats` (postgresql.py)
2. `SQLiteBackend.get_agent_stats` (sqlite.py)
3. `agent_performance_summary` VIEW (postgresql.py schema)

`session_engine.py`'s `session_agent_stats` derives `success_rate` entirely from `get_agent_stats`' output, so no separate engine-level fix was needed. The only other `success_rate` computation in `session_engine.py` (~line 4116) is for `agent_learnings` success/failure counts -- an unrelated metric, left untouched.

## Migration script

`scripts/migrations/reap_stale_executions.py` mirrors #69's `reap_stale_active_sessions.py`: dry-run by default, `--apply` required. **Checked in but NOT executed**, per project policy.

## Tests

`tests/regression/test_issue_70_reconcile_stuck_executions.py` (7 new tests), styled after `test_issue_69_reap_abandoned_sessions.py`:
- Finalizing a session flips still-RUNNING executions to ABANDONED
- Terminal (success/error) executions are untouched by finalize (no regression of #40)
- `reap_stale_executions` flips only rows older than the cutoff, returns the right count
- success_rate excludes abandoned from the denominator (8 success + 2 abandoned = 100%, not 80%)

## Verification

- `pixi run -e ci test`: **570 passed, 74 skipped** (baseline 563 passed + 7 new tests = 570)
- `pixi run -e ci lint`: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)